### PR TITLE
Rename “stripeKey” to “stripePublishableKey”

### DIFF
--- a/backend/data/shop-templates/affiliate/config.json
+++ b/backend/data/shop-templates/affiliate/config.json
@@ -22,7 +22,7 @@
   "pgpPublicKey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nXXXX\n-----END PGP PUBLIC KEY BLOCK-----\n",
   "contentCDN": "",
   "contentHash": "",
-  "stripeKey": "",
+  "stripePublishableKey": "",
 
   "networks": {
     "1": {

--- a/backend/data/shop-templates/multi-product/config.json
+++ b/backend/data/shop-templates/multi-product/config.json
@@ -20,7 +20,7 @@
   "pgpPublicKey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nXXXX\n-----END PGP PUBLIC KEY BLOCK-----\n",
   "contentCDN": "",
   "contentHash": "",
-  "stripeKey": "",
+  "stripePublishableKey": "",
 
   "networks": {
     "1": {

--- a/backend/data/shop-templates/single-product/config.json
+++ b/backend/data/shop-templates/single-product/config.json
@@ -21,7 +21,7 @@
   "pgpPublicKey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nXXXX\n-----END PGP PUBLIC KEY BLOCK-----\n",
   "contentCDN": "",
   "contentHash": "",
-  "stripeKey": "",
+  "stripePublishableKey": "",
 
   "networks": {
     "1": {

--- a/backend/scripts/configs.js
+++ b/backend/scripts/configs.js
@@ -22,7 +22,7 @@ const shopConfig = {
   pgpPublicKey: '',
   contentCDN: '',
   contentHash: '',
-  stripeKey: '',
+  stripePublishableKey: '',
 
   networks: {
     '1': {

--- a/shop/data/example-single/config.json
+++ b/shop/data/example-single/config.json
@@ -21,7 +21,7 @@
   "pgpPublicKey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nXXXX\n-----END PGP PUBLIC KEY BLOCK-----\n",
   "contentCDN": "",
   "contentHash": "",
-  "stripeKey": "",
+  "stripePublishableKey": "",
 
   "networks": {
     "1": {

--- a/shop/data/example/config.json
+++ b/shop/data/example/config.json
@@ -20,7 +20,7 @@
   "pgpPublicKey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nXXXX\n-----END PGP PUBLIC KEY BLOCK-----\n",
   "contentCDN": "",
   "contentHash": "",
-  "stripeKey": "",
+  "stripePublishableKey": "",
 
   "networks": {
     "1": {

--- a/shop/src/components/admin/ConfigWarnings.js
+++ b/shop/src/components/admin/ConfigWarnings.js
@@ -1,0 +1,35 @@
+import React, { useState } from 'react'
+
+const ConfigWarning = ({ config }) => {
+  const [errors, setErrors] = useState([])
+  const [isChecked, setIsChecked] = useState(false)
+  if (config && isChecked == false) {
+    if (config.stripeKey != undefined) {
+      errors.push(`
+        The 'stripeKey' field has been deprecated in the shop's public config file.
+        Please rename this field to 'stripePublishableKey'.`)
+    }
+    setErrors(errors)
+    setIsChecked(true)
+  }
+  return (
+    <div className="warnings">
+      {errors.map((e, i) => (
+        <div key={i}>{e}</div>
+      ))}
+    </div>
+  )
+}
+
+export default ConfigWarning
+
+require('react-styl')(`
+
+  .warnings > div
+    background-color: #ffd1d1
+    border-radius: 10px
+    padding: 0.75rem
+    margin-right: 0.5rem
+    margin-bottom: 0.5rem
+    margin-top: 1.5rem
+`)

--- a/shop/src/pages/admin/settings/Client.js
+++ b/shop/src/pages/admin/settings/Client.js
@@ -1,11 +1,13 @@
 import React from 'react'
 
 import useConfig from 'utils/useConfig'
+import ConfigWarnings from 'components/admin/ConfigWarnings'
 
 const AdminClientSettings = () => {
   const { config } = useConfig()
   return (
     <>
+      <ConfigWarnings config={config} />
       <h4 className="mt-3">Contents of config.json on IPFS</h4>
       <pre>{JSON.stringify(config, null, 2)}</pre>
     </>

--- a/shop/src/pages/checkout/Checkout.js
+++ b/shop/src/pages/checkout/Checkout.js
@@ -26,14 +26,15 @@ const Checkout = () => {
       history.push('/cart')
       return
     }
+    const stripePublishableKey = config.stripePublishableKey || config.stripeKey
     if (window.Stripe) {
-      setStripe(window.Stripe(config.stripeKey))
+      setStripe(window.Stripe(stripePublishableKey))
     } else {
-      if (config.stripe && config.stripeKey) {
+      if (config.stripe && stripePublishableKey) {
         const script = document.createElement('script')
         script.src = 'https://js.stripe.com/v3/'
         script.addEventListener('load', () => {
-          setStripe(window.Stripe(config.stripeKey))
+          setStripe(window.Stripe(stripePublishableKey))
         })
         document.head.appendChild(script)
       }


### PR DESCRIPTION
(Copied PR over from dapp monorepo.)

The field name "StripeKey" is could mean either the the secret key or the public key. I’m concerned with the old name that someone will put in their secret key into this field and cause a mess.

I’ve given this a gentle fallback - the old key is still used, and a warning shown in the /admin/settings/client tab.