### PR TITLE
Super-user startup wizard not saving web3PK and deployDir

### DIFF
--- a/backend/routes/networks.js
+++ b/backend/routes/networks.js
@@ -22,7 +22,8 @@ module.exports = function (app) {
         cloudflareEmail: req.body.cloudflareEmail,
         cloudflareApiKey: req.body.cloudflareApiKey,
         gcpCredentials: req.body.gcpCredentials,
-        domain: req.body.domain
+        domain: req.body.domain,
+        deployDir: req.body.deployDir
       })
     }
 

--- a/backend/routes/shops.js
+++ b/backend/routes/shops.js
@@ -170,7 +170,8 @@ module.exports = function (app) {
         stripeWebhookSecret: '',
         pgpPublicKey: req.body.pgpPublicKey,
         pgpPrivateKey: req.body.pgpPrivateKey,
-        pgpPrivateKeyPass: req.body.pgpPrivateKeyPass
+        pgpPrivateKeyPass: req.body.pgpPrivateKeyPass,
+        web3Pk: req.body.web3Pk
       })
     })
 


### PR DESCRIPTION
The super-user startup wizard was saving not saving the values entered on the web for the server  deployDir and the initial shop web3PK. This fixes that.