### PR TITLE
AutoSSL priming

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -16,14 +16,14 @@ const Defaults = {
     marketplaceContract: process.env.MARKETPLACE_CONTRACT
   },
   '4': {
-    ipfsGateway: 'https://ipfs.staging.originprotocol.com',
-    ipfsApi: 'https://ipfs.staging.originprotocol.com',
+    ipfsGateway: 'https://fs-autossl.staging.ogn.app',
+    ipfsApi: 'https://fs.staging.ogn.app',
     marketplaceContract: '0x3d608cce08819351ada81fc1550841ebc10686fd',
     fetchPastLogs: true
   },
   '1': {
-    ipfsGateway: 'https://ipfs.originprotocol.com',
-    ipfsApi: 'https://ipfs.originprotocol.com',
+    ipfsGateway: 'https://fs-autossl.ogn.app',
+    ipfsApi: 'https://fs.ogn.app',
     marketplaceContract: '0x698ff47b84837d3971118a369c570172ee7e54c2',
     fetchPastLogs: true
   }

--- a/backend/test/const.js
+++ b/backend/test/const.js
@@ -11,6 +11,7 @@ module.exports = {
   TEST_DSHOP_CACHE: TMP_DIR,
   TEST_HASH_1: 'QmZ4tDuvesekSs4qM5ZBKpXiZGun7S2CYtEZRB3DYXkjGx',
   TEST_DOMAIN_1: 'originprotocol.com',
+  BAD_DOMAIN_1: 'thisisnotarealdomaindotcom135.com',
   TEST_LISTING_ID_1: '999-001-999',
   TEST_SHOP_TOKEN_1: 'test-shop',
   TEST_UNSTOPPABLE_DOMAIN_1: 'testname.crypto',

--- a/backend/test/dns.utils.test.js
+++ b/backend/test/dns.utils.test.js
@@ -1,0 +1,24 @@
+const chai = require('chai')
+const expect = chai.expect
+
+const {
+  isPublicDNSName,
+  isUnsoppableName,
+  isCryptoName
+} = require('../utils/dns')
+
+const { TEST_DOMAIN_1, TEST_UNSTOPPABLE_DOMAIN_1 } = require('./const')
+
+describe('DNS Utils', () => {
+  it('should recognize an Unstoppable domain', async () => {
+    expect(isUnsoppableName(TEST_UNSTOPPABLE_DOMAIN_1)).to.be.true
+  })
+
+  it('should recognize crypto domains', async () => {
+    expect(isCryptoName(TEST_UNSTOPPABLE_DOMAIN_1)).to.be.true
+  })
+
+  it('should recognize non-crypto domains', async () => {
+    expect(isPublicDNSName(TEST_DOMAIN_1)).to.be.true
+  })
+})

--- a/backend/test/http.utils.test.js
+++ b/backend/test/http.utils.test.js
@@ -1,0 +1,31 @@
+const chai = require('chai')
+const expect = chai.expect
+
+const { getHTTPS } = require('../utils/http')
+
+const { TEST_DOMAIN_1, BAD_DOMAIN_1 } = require('./const')
+
+describe('HTTP Utils', () => {
+  it('should make a successful HTTPS GET request to a known domain', async () => {
+    expect(await getHTTPS(`https://www.${TEST_DOMAIN_1}`)).to.be.undefined
+  })
+
+  it('should fail at making an HTTPS GET request to a non-existant domain', async () => {
+    return getHTTPS(`https://www.${BAD_DOMAIN_1}`).catch((err) =>
+      expect(err)
+        .to.be.an('error')
+        .with.property('message')
+        .that.has.string('ENOTFOUND')
+    )
+  })
+
+  // TODO: Remove this
+  it('should sleep for 3 seconds', async () => {
+    const start = +new Date()
+    await (async () => {
+      return new Promise((resolve) => setTimeout(resolve, 3000))
+    })()
+    const end = +new Date()
+    expect(end - start).to.be.above(2999)
+  })
+})

--- a/backend/test/http.utils.test.js
+++ b/backend/test/http.utils.test.js
@@ -18,14 +18,4 @@ describe('HTTP Utils', () => {
         .that.has.string('ENOTFOUND')
     )
   })
-
-  // TODO: Remove this
-  it('should sleep for 3 seconds', async () => {
-    const start = +new Date()
-    await (async () => {
-      return new Promise((resolve) => setTimeout(resolve, 3000))
-    })()
-    const end = +new Date()
-    expect(end - start).to.be.above(2999)
-  })
 })

--- a/backend/utils/deployShop.js
+++ b/backend/utils/deployShop.js
@@ -298,6 +298,7 @@ async function deployShop({
     domain = dnsProvider ? `https://${subdomain}.${zone}` : null
     await configureShopDNS({ network, subdomain, zone, hash, dnsProvider })
     if (network.ipfs) {
+      // Intentionally not awating on this so we can return to the user faster
       triggerAutoSSL(domain, network.ipfs)
     }
   }

--- a/backend/utils/deployShop.js
+++ b/backend/utils/deployShop.js
@@ -65,7 +65,7 @@ async function triggerAutoSSL(url, autoSSLHost) {
 
   log.debug(`Making request to ${url.hostname} with header (Host: ${hostname})`)
 
-  while (!success && attempts <= AUTOSSL_MAX_ATTEMPTS) {
+  for (;;) {
     try {
       await getHTTPS({
         host: url.hostname,

--- a/backend/utils/deployShop.js
+++ b/backend/utils/deployShop.js
@@ -8,11 +8,14 @@ const { getLogger } = require('../utils/logger')
 
 const { getConfig } = require('./encryptedConfig')
 const prime = require('./primeIpfs')
+const { getHTTPS } = require('./http')
 const setCloudflareRecords = require('./dns/cloudflare')
 const setCloudDNSRecords = require('./dns/clouddns')
 
-const log = getLogger('utils.handleLog')
+const log = getLogger('utils.deployShop')
 const LOCAL_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0']
+const AUTOSSL_MAX_ATTEMPTS = 5
+const AUTOSSL_BACKOFF = 30000
 
 /**
  * Convert an HTTP URL into a multiaddr
@@ -44,6 +47,61 @@ function urlToMultiaddr(v, opts) {
   )}${url.pathname}`
 }
 
+/**
+ * Trigger AutoSSL to generate cert
+ *
+ * @param url {T} URL object or string to connect to
+ * @returns {boolean} if it was successful
+ */
+async function triggerAutoSSL(url, autoSSLHost) {
+  let success = false
+  let attempts = 1
+
+  url = url instanceof URL ? url : new URL(url)
+  const hostname = url.hostname
+  url.hostname = autoSSLHost.includes('//') ? autoSSLHost.split('//').slice(-1) : autoSSLHost
+
+  log.debug(`Making request to ${url.hostname} with header (Host: ${hostname})`)
+
+  while (!success && attempts <= AUTOSSL_MAX_ATTEMPTS) {
+    try {
+      await getHTTPS({
+        host: url.hostname,
+        path: url.pathname,
+        port: url.port || 443,
+        servername: hostname,
+        headers: {
+          host: hostname
+        }
+      })
+      success = true
+      break
+    } catch (err) {
+      log.info(`Error when attempting to trigger AutoSSL on attempt ${attempts}:`, err)
+
+      if (attempts <= AUTOSSL_MAX_ATTEMPTS) {
+        // sleep with backoff
+        await (async () => {
+          log.debug(`AutoSSL trigger backing off by ${attempts * AUTOSSL_BACKOFF}ms`)
+          return new Promise(resolve => setTimeout(resolve, attempts * AUTOSSL_BACKOFF))
+        })()
+
+        attempts += 1
+      } else {
+        break
+      }
+    }
+  }
+
+  if (!success) {
+    log.error('Error trying to auto-trigger AutoSSL')
+  } else {
+    log.debug('AutoSSL trigger completed')
+  }
+
+  return success
+}
+
 async function configureShopDNS({
   network,
   subdomain,
@@ -52,13 +110,15 @@ async function configureShopDNS({
   dnsProvider
 }) {
   const networkConfig = getConfig(network.config)
+  const gatewayURL = new URL(network.ipfs)
+  const gatewayHost = gatewayURL.hostname
 
   if (dnsProvider === 'cloudflare') {
     if (!networkConfig.cloudflareApiKey) {
       log.warn('Cloudflare DNS Proider selected but no credentials configured!')
     } else {
       await setCloudflareRecords({
-        ipfsGateway: 'ipfs-prod.ogn.app',
+        ipfsGateway: gatewayHost,
         zone,
         subdomain,
         hash,
@@ -73,7 +133,7 @@ async function configureShopDNS({
       log.warn('GCP DNS Proider selected but no credentials configured!')
     } else {
       await setCloudDNSRecords({
-        ipfsGateway: 'ipfs-prod.ogn.app',
+        ipfsGateway: gatewayHost,
         zone,
         subdomain,
         hash,
@@ -228,6 +288,9 @@ async function deployShop({
   if (subdomain) {
     domain = dnsProvider ? `https://${subdomain}.${zone}` : null
     await configureShopDNS({ network, subdomain, zone, hash, dnsProvider })
+    if (network.ipfs) {
+      triggerAutoSSL(domain, network.ipfs)
+    }
   }
 
   if (hash) {

--- a/backend/utils/deployShop.js
+++ b/backend/utils/deployShop.js
@@ -59,7 +59,9 @@ async function triggerAutoSSL(url, autoSSLHost) {
 
   url = url instanceof URL ? url : new URL(url)
   const hostname = url.hostname
-  url.hostname = autoSSLHost.includes('//') ? autoSSLHost.split('//').slice(-1) : autoSSLHost
+  url.hostname = autoSSLHost.includes('//')
+    ? autoSSLHost.split('//').slice(-1)
+    : autoSSLHost
 
   log.debug(`Making request to ${url.hostname} with header (Host: ${hostname})`)
 
@@ -77,13 +79,20 @@ async function triggerAutoSSL(url, autoSSLHost) {
       success = true
       break
     } catch (err) {
-      log.info(`Error when attempting to trigger AutoSSL on attempt ${attempts}:`, err)
+      log.info(
+        `Error when attempting to trigger AutoSSL on attempt ${attempts}:`,
+        err
+      )
 
       if (attempts <= AUTOSSL_MAX_ATTEMPTS) {
         // sleep with backoff
         await (async () => {
-          log.debug(`AutoSSL trigger backing off by ${attempts * AUTOSSL_BACKOFF}ms`)
-          return new Promise(resolve => setTimeout(resolve, attempts * AUTOSSL_BACKOFF))
+          log.debug(
+            `AutoSSL trigger backing off by ${attempts * AUTOSSL_BACKOFF}ms`
+          )
+          return new Promise((resolve) =>
+            setTimeout(resolve, attempts * AUTOSSL_BACKOFF)
+          )
         })()
 
         attempts += 1

--- a/backend/utils/dns/index.js
+++ b/backend/utils/dns/index.js
@@ -37,8 +37,6 @@ function isPublicDNSName(v) {
   )
 }
 
-
-
 module.exports = {
   isPublicDNSName,
   isUnsoppableName,

--- a/backend/utils/dns/index.js
+++ b/backend/utils/dns/index.js
@@ -37,6 +37,8 @@ function isPublicDNSName(v) {
   )
 }
 
+
+
 module.exports = {
   isPublicDNSName,
   isUnsoppableName,

--- a/backend/utils/http.js
+++ b/backend/utils/http.js
@@ -1,0 +1,29 @@
+const https = require('https')
+
+const { getLogger } = require('../utils/logger')
+
+const log = getLogger('utils.http')
+
+/**
+ * Make a simple HTTPS GET request without caring about HTTP status codes.
+ * Should error only on connection errors.
+ *
+ * @param opts {object} Object to be gien to https.get as a request
+ */
+async function getHTTPS(opts) {
+  log.debug(`getHTTPS(${opts.servername}:${opts.port}${opts.path})`)
+  return await new Promise((resolve, reject) => {
+    https
+      .get(opts, (response) => {
+        log.debug(`HTTPS GET returned ${response.statusCode}`)
+        resolve()
+      })
+      .on('error', (err) => {
+        console.trace(err)
+        log.error(`Error GETting ${opts.servername}${opts.path}`)
+        reject(err)
+      })
+  })
+}
+
+module.exports = { getHTTPS }


### PR DESCRIPTION
This will make a request to the issuer to try and trigger AutoSSL before the user does.  It's a bit of a race between this and the user with the way things are right now.  It takes a couple of minutes for Let's Encrypt to resolve the new DNS record.

This also changes the DNS configuration to use the network-level configured IPFS gateway instead of hardcoded values.  We need to make sure that's pointed at the issuer(it is on primary deployments, prod and staging).

There's a reasonable chance this will do the thing before the user, but think we might still want to add some UI stall tactics(like a spinner!).

Ref: #118 