### PR TITLE
Adds some defensive checks for files when using mv

### DIFF
--- a/backend/routes/shops.js
+++ b/backend/routes/shops.js
@@ -498,8 +498,15 @@ module.exports = function (app) {
         try {
           for (const file of allFiles) {
             await new Promise((resolve, reject) => {
-              mv(file.path, `${uploadDir}/${file.name}`, (err) => {
-                return err ? reject(err) : resolve()
+              fs.stat(file.path, (err, fstat) => {
+                if (err) return reject(err)
+                if (!fstat.isFile()) {
+                  return reject(`${file.path} does not exist or is not a file`)
+                }
+
+                mv(file.path, `${uploadDir}/${file.name}`, (err) => {
+                  return err ? reject(err) : resolve()
+                })
               })
             })
           }
@@ -535,14 +542,24 @@ module.exports = function (app) {
         }
 
         const { file } = files
+        if (!file) {
+          return res.json({ success: false, reason: 'no-file' })
+        }
         if (Array.isArray(file)) {
           return res.json({ success: false, reason: 'too-many-files' })
         }
 
         try {
           await new Promise((resolve, reject) => {
-            mv(file.path, `${uploadDir}/${file.name}`, (err) => {
-              return err ? reject(err) : resolve()
+            fs.stat(file.path, (err, fstat) => {
+              if (err) return reject(err)
+              if (!fstat.isFile()) {
+                return reject(`${file.path} does not exist or is not a file`)
+              }
+
+              mv(file.path, `${uploadDir}/${file.name}`, (err) => {
+                return err ? reject(err) : resolve()
+              })
             })
           })
 


### PR DESCRIPTION
Adds some defensive checks and makes sure that a file was uploaded before trying to move it.  Don't think this is super common, but spotted this on the rinkeby backend recently.

Closes #148