### PR TITLE
Forward shipping data from Printful

### DIFF
--- a/backend/routes/printful.js
+++ b/backend/routes/printful.js
@@ -5,7 +5,8 @@ const {
   fetchOrder,
   placeOrder,
   confirmOrder,
-  fetchShippingEstimate
+  fetchShippingEstimate,
+  processShippedEvent
 } = require('../utils/printful')
 
 module.exports = function (app) {
@@ -51,5 +52,13 @@ module.exports = function (app) {
     const { status, ...resp } = await fetchShippingEstimate(apiKey, req.body)
 
     return res.status(status || 200).send(resp)
+  })
+
+  app.post('/printful-webhook', async (req, res) => {
+    const { data } = req.body
+
+    await processShippedEvent(data)
+
+    return res.status(200).end()
   })
 }

--- a/backend/routes/printful.js
+++ b/backend/routes/printful.js
@@ -6,7 +6,8 @@ const {
   placeOrder,
   confirmOrder,
   fetchShippingEstimate,
-  processShippedEvent
+  processShippedEvent,
+  getPrintfulWebhookURL
 } = require('../utils/printful')
 
 module.exports = function (app) {
@@ -54,7 +55,7 @@ module.exports = function (app) {
     return res.status(status || 200).send(resp)
   })
 
-  app.post('/printful-webhook', async (req, res) => {
+  app.post(getPrintfulWebhookURL(), async (req, res) => {
     const { data } = req.body
 
     await processShippedEvent(data)

--- a/backend/routes/shops.js
+++ b/backend/routes/shops.js
@@ -35,6 +35,10 @@ const { configureShopDNS, deployShop } = require('../utils/deployShop')
 const { DSHOP_CACHE } = require('../utils/const')
 const { isPublicDNSName } = require('../utils/dns')
 const { getLogger } = require('../utils/logger')
+const {
+  deregisterPrintfulWebhook,
+  registerPrintfulWebhook
+} = require('../utils/printful')
 
 const downloadProductData = require('../scripts/printful/downloadProductData')
 const downloadPrintfulMockups = require('../scripts/printful/downloadPrintfulMockups')
@@ -795,6 +799,16 @@ module.exports = function (app) {
         stripeOpts.stripeWebhookSecret = secret
       } else if (req.body.stripeWebhookSecret) {
         stripeOpts.stripeWebhookSecret = req.body.stripeWebhookSecret
+      }
+
+      // Printful webhooks
+      if (req.body.printful) {
+        await registerPrintfulWebhook({
+          ...existingConfig,
+          ...req.body
+        })
+      } else if (existingConfig.printful && !req.body.printful) {
+        await deregisterPrintfulWebhook(existingConfig)
       }
 
       const newConfig = setConfig(

--- a/backend/utils/printful.js
+++ b/backend/utils/printful.js
@@ -218,6 +218,11 @@ const autoFulfillOrder = async (orderObj, shopConfig, shop) => {
   }
 }
 
+const getPrintfulWebhookURL = () => {
+  const secret = process.env.PRINTFUL_WEBHOOK_SECRET
+  return `/printful-webhook${secret ? '-' + secret : ''}`
+}
+
 const registerPrintfulWebhook = async (shopConfig) => {
   try {
     const webhookHost = get(shopConfig, `publicUrl`)
@@ -231,7 +236,7 @@ const registerPrintfulWebhook = async (shopConfig) => {
 
     const url = `${PrintfulURL}/webhooks`
 
-    const webhookURL = `${webhookHost}/printful-webhook`
+    const webhookURL = `${webhookHost}${getPrintfulWebhookURL()}`
 
     const registerData = {
       url: webhookURL,
@@ -322,5 +327,6 @@ module.exports = {
   autoFulfillOrder,
   registerPrintfulWebhook,
   deregisterPrintfulWebhook,
-  processShippedEvent
+  processShippedEvent,
+  getPrintfulWebhookURL
 }

--- a/backend/utils/templates/email.js
+++ b/backend/utils/templates/email.js
@@ -14,20 +14,41 @@ module.exports = (vars) => `
     </mj-section>
     <mj-section>
       <mj-column>
-        <mj-text mj-class="large">Thank you for your purchase!</mj-text>
+        <mj-text mj-class="large">
+          ${
+            vars.trackingInfo
+              ? 'Your order has been shipped!'
+              : 'Thank you for your purchase!'
+          }
+        </mj-text>
         <mj-text mj-class="light">
-          Hi ${
-            vars.firstName
-          }, we're getting your order ready to be shipped. We will notify you when it has been sent.
+          Hi ${vars.firstName}, ${
+  vars.trackingInfo
+    ? `Just letting you know that your order #${vars.orderNumber} has been sent out!`
+    : `we're getting your order ready to be shipped. We will notify you when it has been sent.`
+}
         </mj-text>
-        <mj-text css-class="view-order">
-          <a href="${vars.orderUrl}" class="btn">
-            View your order
-          </a>
-          <span class="visit-store">
-           or <a href="${vars.storeUrl}">Visit our store</a>
-          </span>
-        </mj-text>
+        ${
+          vars.trackingInfo
+            ? `
+          <mj-text mj-class="light">
+            <div>Here's the tracking number: ${vars.trackingInfo.trackingNumber}</div>
+            <div class="mb-10">${vars.trackingInfo.trackingService}</div>
+            <div class="mb-10"><a class="btn" href="${vars.trackingInfo.trackingUrl}">Track your order</a></div>
+            <div>Note: Tracking information can take up to 48 hours to be updated after the order is shipped.</div>
+          </mj-text>
+        `
+            : `
+          <mj-text css-class="view-order">
+            <a href="${vars.orderUrl}" class="btn">
+              View your order
+            </a>
+            <span class="visit-store">
+            or <a href="${vars.storeUrl}">Visit our store</a>
+            </span>
+          </mj-text>
+        `
+        }
       </mj-column>
     </mj-section>
     <mj-divider />

--- a/backend/utils/templates/head.js
+++ b/backend/utils/templates/head.js
@@ -72,6 +72,10 @@ module.exports = () => `
       border-top: 2px solid lightgrey;
       padding-top: 20px;
     }
+
+    .mb-10 {
+      margin-bottom: 10px
+    }
   </mj-style>
   <mj-style>
     @media (max-width: 400px) {


### PR DESCRIPTION
Closes #40.

Printful webhook doesn't have any signature or any kind of authorization in the requests. So, the webhook endpoint is kind of open now. Anyone can abuse it. Have added a `PRINTFUL_WEBHOOK_SECRET` environment variable to the backend, that can be used to make the endpoint not-so-static.  