### PR TITLE
Prevent setting discounts on other stores.

### DIFF
--- a/backend/routes/discounts.js
+++ b/backend/routes/discounts.js
@@ -32,8 +32,8 @@ module.exports = function (app) {
 
   app.post('/discounts', authSellerAndShop, async (req, res) => {
     const discount = await Discount.create({
-      shopId: req.shop.id,
-      ...req.body
+      ...req.body,
+      shopId: req.shop.id
     })
     res.json({ success: true, discount })
   })


### PR DESCRIPTION
 Ensure shopId overrides user fields, rather than the other way around.