### PR TITLE
Fix bug in Printful API route

### DIFF
--- a/backend/routes/printful.js
+++ b/backend/routes/printful.js
@@ -16,6 +16,9 @@ const log = getLogger('routes.printful')
 const { ExternalEvent } = require('../models')
 
 module.exports = function (app) {
+  /**
+   * Makes an API call to Printful to get details about a specific order.
+   */
   app.get(
     '/orders/:orderId/printful',
     authSellerAndShop,

--- a/backend/utils/printful.js
+++ b/backend/utils/printful.js
@@ -39,7 +39,7 @@ const PrintfulWebhookEvents = {
  *    Example: '1-001-81-231'
  * @returns {Promise<{message: string, status: integer}|{[p: string]: *}|{message: (*|string), status: *}>}
  */
-const fetchOrder2 = async (apiKey, orderId) => {
+const fetchOrder = async (apiKey, orderId) => {
   if (!apiKey) {
     return {
       status: 500,

--- a/backend/utils/printful.js
+++ b/backend/utils/printful.js
@@ -37,12 +37,13 @@ const PrintfulWebhookEvents = {
  * @param {string} orderId: dshop order id.
  *    Format: <networkId>-<contractVersion>-<listingId>-<offerId>.
  *    Example: '1-001-81-231'
- * @returns {Promise<{message: string, status: integer}|{[p: string]: *}|{message: (*|string), status: *}>}
+ * @returns {Promise<{status: number, success: boolean, message: string}|{status: number, success: boolean, ...Object}>}
  */
 const fetchOrder = async (apiKey, orderId) => {
   if (!apiKey) {
     return {
       status: 500,
+      success: false,
       message: 'Missing Printful API configuration'
     }
   }
@@ -59,6 +60,7 @@ const fetchOrder = async (apiKey, orderId) => {
   if (!result.ok) {
     return {
       status: result.status,
+      success: false,
       message: json.result || 'Printful API call failed'
     }
   }

--- a/backend/utils/printful.js
+++ b/backend/utils/printful.js
@@ -31,11 +31,19 @@ const PrintfulWebhookEvents = {
   OrderRemoveHold: 'order_remove_hold'
 }
 
-const fetchOrder = async (apiKey, orderId) => {
+/**
+ * Fetches a Printful order.
+ * @param {string} apiKey: Prinful API key.
+ * @param {string} orderId: dshop order id.
+ *    Format: <networkId>-<contractVersion>-<listingId>-<offerId>.
+ *    Example: '1-001-81-231'
+ * @returns {Promise<{message: string, status: integer}|{[p: string]: *}|{message: (*|string), status: *}>}
+ */
+const fetchOrder2 = async (apiKey, orderId) => {
   if (!apiKey) {
     return {
       status: 500,
-      message: 'Missing printful API configuration'
+      message: 'Missing Printful API configuration'
     }
   }
 
@@ -47,8 +55,15 @@ const fetchOrder = async (apiKey, orderId) => {
       authorization: `Basic ${apiAuth}`
     }
   })
-  const json = await result.json()
+  const json = (await result.json()) || {}
+  if (!result.ok) {
+    return {
+      status: result.status,
+      message: json.result || 'Printful API call failed'
+    }
+  }
   return {
+    status: 200,
     success: true,
     ...get(json, 'result', {})
   }

--- a/backend/utils/printful.js
+++ b/backend/utils/printful.js
@@ -75,6 +75,7 @@ const placeOrder = async (apiKey, orderData, opts = {}) => {
   if (!apiKey) {
     return {
       status: 500,
+      success: false,
       message: 'Missing printful API configuration'
     }
   }


### PR DESCRIPTION
The route for getting the details of an order would fail if the order id is not found on the Prinful side.
The fix is to check the HTTP request status code before trying to interpret the JSON.

Should fix bug #191 