### PR TITLE
Fix migration

### DIFF
--- a/backend/db/migrations/20200710134411-changeEventTypeToEnum.js
+++ b/backend/db/migrations/20200710134411-changeEventTypeToEnum.js
@@ -3,25 +3,21 @@
 const { PrintfulWebhookEvents, ExternalServices } = require('../../utils/enums')
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.changeColumn('external_events', 'event_type', {
-        type: Sequelize.ENUM(...Object.values(PrintfulWebhookEvents))
-      }),
-      queryInterface.changeColumn('external_events', 'service', {
-        type: Sequelize.ENUM(...Object.values(ExternalServices))
-      })
-    ])
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('external_events', 'event_type', {
+      type: Sequelize.ENUM(...Object.values(PrintfulWebhookEvents))
+    })
+    await queryInterface.changeColumn('external_events', 'service', {
+      type: Sequelize.ENUM(...Object.values(ExternalServices))
+    })
   },
 
-  down: (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.changeColumn('external_events', 'event_type', {
-        type: Sequelize.STRING
-      }),
-      queryInterface.changeColumn('external_events', 'service', {
-        type: Sequelize.STRING
-      }),
-    ])
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('external_events', 'event_type', {
+      type: Sequelize.STRING
+    })
+    await queryInterface.changeColumn('external_events', 'service', {
+      type: Sequelize.STRING
+    })
   }
 }

--- a/shop/src/pages/admin/settings/_VerifyButton.js
+++ b/shop/src/pages/admin/settings/_VerifyButton.js
@@ -9,7 +9,7 @@ const VerifyButton = ({ onVerify, children }) => {
   const onVerifyClick = async () => {
     try {
       setVerifying(true)
- 
+
       const { valid } = await onVerify()
 
       if (valid) {
@@ -37,13 +37,13 @@ const VerifyButton = ({ onVerify, children }) => {
     }
   }
   return (
-    <button 
-      className="btn btn-outline-primary mr-2" 
+    <button
+      className="btn btn-outline-primary mr-2"
       type="button"
       onClick={onVerifyClick}
       disabled={verifying}
     >
-      {verifying ? 'Verifying...' : (children || 'Verify')}
+      {verifying ? 'Verifying...' : children || 'Verify'}
     </button>
   )
 }

--- a/shop/src/pages/admin/settings/payments/List.js
+++ b/shop/src/pages/admin/settings/payments/List.js
@@ -197,7 +197,9 @@ const PaymentSettings = () => {
         <ProcessorsList processors={Processors} />
 
         {connectModal === 'web3' && <Web3Modal onClose={onCloseModal} />}
-        {connectModal === 'stripe' && <StripeModal onClose={onCloseModal} initialConfig={shopConfig} />}
+        {connectModal === 'stripe' && (
+          <StripeModal onClose={onCloseModal} initialConfig={shopConfig} />
+        )}
         {connectModal === 'uphold' && <UpholdModal onClose={onCloseModal} />}
 
         <ContractSettings {...{ state, setState, config }} />


### PR DESCRIPTION
Executing the queryInterface.changeColumn for 2 columns at once was causing some errors (because it involves backing up the data in an intermediary table).
See logs:
```
== 20200710134411-changeEventTypeToEnum: migrating =======
Executing (default): PRAGMA TABLE_INFO(`external_events`);
Executing (default): PRAGMA TABLE_INFO(`external_events`);
Executing (default): PRAGMA INDEX_LIST(`external_events`)
Executing (default): PRAGMA INDEX_LIST(`external_events`)
Executing (default): PRAGMA foreign_key_list(external_events)
Executing (default): PRAGMA foreign_key_list(external_events)
Executing (default): CREATE TABLE IF NOT EXISTS `external_events_backup` (`id` INTEGER PRIMARY KEY, `shop_id` INTEGER REFERENCES `shops` (`id`), `service` VARCHAR(255), `event_type` TEXT, `data` JSON, `created_at` DATETIME, `updated_at` DATETIME);
Executing (default): CREATE TABLE IF NOT EXISTS `external_events_backup` (`id` INTEGER PRIMARY KEY, `shop_id` INTEGER REFERENCES `shops` (`id`), `service` TEXT, `event_type` TEXT, `data` JSON, `created_at` DATETIME, `updated_at` DATETIME);
Executing (default): INSERT INTO `external_events_backup` SELECT `id`, `shop_id`, `service`, `event_type`, `data`, `created_at`, `updated_at` FROM `external_events`;
Executing (default): INSERT INTO `external_events_backup` SELECT `id`, `shop_id`, `service`, `event_type`, `data`, `created_at`, `updated_at` FROM `external_events`;
Executing (default): DROP TABLE `external_events`;
Executing (default): DROP TABLE `external_events`;
Executing (default): CREATE TABLE IF NOT EXISTS `external_events` (`id` INTEGER PRIMARY KEY, `shop_id` INTEGER REFERENCES `shops` (`id`), `service` VARCHAR(255), `event_type` TEXT, `data` JSON, `created_at` DATETIME, `updated_at` DATETIME);

```