### PR TITLE
Sentry back-end integration

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -114,7 +114,7 @@ app.get('*', (req, res, next) => {
   serveStatic(dir)(req, res, next)
 })
 
-// must come after controllers and before other error middleware
+// Must come after controllers and before any other error middleware.
 app.use(Sentry.Handlers.errorHandler())
 
 // The custom error handler must be defined last.

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,6 +40,7 @@
     "envkey": "^1.2.8",
     "ethereumjs-util": "^7.0.2",
     "express": "^4.17.1",
+    "express-promise-router": "4.0.1",
     "express-session": "^1.17.1",
     "form-data": "^3.0.0",
     "formidable": "^1.2.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -56,6 +56,7 @@
     "pg": "8.3.0",
     "randomstring": "^1.1.5",
     "reconnecting-websocket": "^4.4.0",
+    "@sentry/node": "^5.19.2",
     "sequelize": "^5.21.10",
     "sequelize-cli": "^5.5.1",
     "serve-static": "^1.14.1",

--- a/backend/queues/ui.js
+++ b/backend/queues/ui.js
@@ -9,8 +9,8 @@ const { authSuperUser } = require('../routes/_auth')
  * If we are not using bull for a queue, don't setup the UI for it.
  * @param {*} app
  */
-function noUi(app) {
-  app.get('/super-admin/queue', authSuperUser, function (req, res) {
+function noUi(router) {
+  router.get('/super-admin/queue', authSuperUser, function (req, res) {
     res.send('Redis is not configured. Queuing disabled.')
   })
 }
@@ -19,7 +19,7 @@ function noUi(app) {
  * Use the bull board queue UI, and attach it to all our queues.
  * @param {*} app
  */
-function bullBoardUI(app) {
+function bullBoardUI(router) {
   const { UI, setQueues } = require('bull-board')
   const queues = require('./queues')
 
@@ -32,13 +32,13 @@ function bullBoardUI(app) {
   setQueues(allQueues)
 
   // Use the UI
-  app.use('/super-admin/queue', authSuperUser, UI)
+  router.use('/super-admin/queue', authSuperUser, UI)
 }
 
-module.exports = function (app) {
+module.exports = function (router) {
   if (REDIS_URL != undefined) {
-    bullBoardUI(app)
+    bullBoardUI(router)
   } else {
-    noUi(app)
+    noUi(router)
   }
 }

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -41,7 +41,6 @@ async function getGcpSuperAdminPassword() {
 
 module.exports = function (router) {
   router.get('/auth', async (req, res) => {
-    throw new Error('Shall I use Router or App?')
     const userCount = await Seller.count()
     if (!userCount) {
       return res.json({ success: false, reason: 'no-users', setup: true })

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -39,8 +39,9 @@ async function getGcpSuperAdminPassword() {
   return password
 }
 
-module.exports = function (app) {
-  app.get('/auth', async (req, res) => {
+module.exports = function (router) {
+  router.get('/auth', async (req, res) => {
+    throw new Error('Shall I use Router or App?')
     const userCount = await Seller.count()
     if (!userCount) {
       return res.json({ success: false, reason: 'no-users', setup: true })
@@ -156,14 +157,14 @@ module.exports = function (app) {
     res.json(response)
   })
 
-  app.get('/auth/:email', async (req, res) => {
+  router.get('/auth/:email', async (req, res) => {
     // TODO: Add some rate limiting here
     const { email } = req.params
     const seller = await Seller.findOne({ where: { email } })
     return res.sendStatus(seller === null ? 404 : 204)
   })
 
-  app.post('/superuser/login', async (req, res) => {
+  router.post('/superuser/login', async (req, res) => {
     const email = get(req.body, 'email', '').toLowerCase()
     const seller = await Seller.findOne({ where: { email, superuser: true } })
     if (!seller) {
@@ -178,7 +179,7 @@ module.exports = function (app) {
     }
   })
 
-  app.post('/auth/login', async (req, res) => {
+  router.post('/auth/login', async (req, res) => {
     const seller = await Seller.findOne({ where: { email: req.body.email } })
     if (!seller) {
       return res.status(404).send({
@@ -209,13 +210,13 @@ module.exports = function (app) {
     })
   }
 
-  app.post('/auth/logout', logoutHandler)
+  router.post('/auth/logout', logoutHandler)
 
   /**
    * Creates a super admin account.
    * Called during initial onboarding flow for standing up the system.
    */
-  app.post('/auth/registration', async (req, res) => {
+  router.post('/auth/registration', async (req, res) => {
     const sellerCount = await numSellers()
     if (sellerCount > 0) {
       log.warn(
@@ -268,7 +269,7 @@ module.exports = function (app) {
     res.json({ success: true })
   })
 
-  app.delete('/auth/registration', async (req, res) => {
+  router.delete('/auth/registration', async (req, res) => {
     const { sellerId } = req.session
 
     if (!sellerId) {
@@ -281,18 +282,23 @@ module.exports = function (app) {
     res.json({ success: false, destroy })
   })
 
-  app.get('/config', authSellerAndShop, authRole('admin'), async (req, res) => {
-    const config = encConf.getConfig(req.shop.config)
-    return res.json({
-      success: true,
-      config: {
-        ...config,
-        ...pick(req.shop.dataValues, ['hostname', 'hasChanges'])
-      }
-    })
-  })
+  router.get(
+    '/config',
+    authSellerAndShop,
+    authRole('admin'),
+    async (req, res) => {
+      const config = encConf.getConfig(req.shop.config)
+      return res.json({
+        success: true,
+        config: {
+          ...config,
+          ...pick(req.shop.dataValues, ['hostname', 'hasChanges'])
+        }
+      })
+    }
+  )
 
-  app.get('/password', authShop, async (req, res) => {
+  router.get('/password', authShop, async (req, res) => {
     const password = await encConf.get(req.shop.id, 'password')
     if (!password) {
       return res.json({ success: true })
@@ -302,7 +308,7 @@ module.exports = function (app) {
     res.json({ success: false })
   })
 
-  app.post('/password', authShop, async (req, res) => {
+  router.post('/password', authShop, async (req, res) => {
     const password = await encConf.get(req.shop.id, 'password')
     if (req.body.password === password) {
       req.session.authedShop = req.shop.id

--- a/backend/routes/collections.js
+++ b/backend/routes/collections.js
@@ -8,8 +8,8 @@ const { DSHOP_CACHE } = require('../utils/const')
 const encConf = require('../utils/encryptedConfig')
 const { findShopByHostname } = require('../utils/shop')
 
-module.exports = function (app) {
-  app.put(
+module.exports = function (router) {
+  router.put(
     '/collections',
     authSellerAndShop,
     authRole('admin'),
@@ -33,7 +33,7 @@ module.exports = function (app) {
     }
   )
 
-  app.put(
+  router.put(
     '/collections/:collectionId',
     authSellerAndShop,
     authRole('admin'),
@@ -72,7 +72,7 @@ module.exports = function (app) {
     }
   )
 
-  app.get(
+  router.get(
     '(/collections/:collection)?/products/:product',
     findShopByHostname,
     async (req, res) => {

--- a/backend/routes/collections.js
+++ b/backend/routes/collections.js
@@ -4,9 +4,9 @@ const path = require('path')
 const pick = require('lodash/pick')
 
 const { authSellerAndShop, authRole } = require('./_auth')
-const { findShopByHostname } = require('./utils/shop')
 const { DSHOP_CACHE } = require('../utils/const')
-const encConf = require('./utils/encryptedConfig')
+const encConf = require('../utils/encryptedConfig')
+const { findShopByHostname } = require('../utils/shop')
 
 module.exports = function (app) {
   app.put(

--- a/backend/routes/collections.js
+++ b/backend/routes/collections.js
@@ -1,9 +1,12 @@
+const fetch = require('node-fetch')
 const fs = require('fs')
 const path = require('path')
 const pick = require('lodash/pick')
 
 const { authSellerAndShop, authRole } = require('./_auth')
+const { findShopByHostname } = require('./utils/shop')
 const { DSHOP_CACHE } = require('../utils/const')
+const encConf = require('./utils/encryptedConfig')
 
 module.exports = function (app) {
   app.put(
@@ -65,6 +68,46 @@ module.exports = function (app) {
         res.send({ success: true })
       } catch (e) {
         res.json({ success: false })
+      }
+    }
+  )
+
+  app.get(
+    '(/collections/:collection)?/products/:product',
+    findShopByHostname,
+    async (req, res) => {
+      if (!res.shop) {
+        return res.send('')
+      }
+      let html
+      try {
+        html = fs.readFileSync(`${__dirname}/public/index.html`).toString()
+      } catch (e) {
+        return res.send('')
+      }
+
+      const dataUrl = await encConf.get(req.shop.id, 'dataUrl')
+
+      const url = `${dataUrl}${req.params.product}/data.json`
+      const dataRaw = await fetch(url)
+
+      if (dataRaw.ok) {
+        const data = await dataRaw.json()
+        let modifiedHtml = html
+        if (data.title) {
+          modifiedHtml = modifiedHtml.replace(
+            /<title>.*<\/title>/,
+            `<title>${data.title}</title>`
+          )
+        }
+        if (data.head) {
+          modifiedHtml = modifiedHtml
+            .replace('</head>', data.head.join('\n') + '\n</head>')
+            .replace('DATA_URL', dataUrl)
+        }
+        res.send(modifiedHtml)
+      } else {
+        res.send(html)
       }
     }
   )

--- a/backend/routes/discounts.js
+++ b/backend/routes/discounts.js
@@ -5,8 +5,8 @@ const { authShop, authSellerAndShop } = require('./_auth')
 
 const { validateDiscount, getSafeDiscountProps } = require('../utils/discounts')
 
-module.exports = function (app) {
-  app.post('/check-discount', authShop, async (req, res) => {
+module.exports = function (router) {
+  router.post('/check-discount', authShop, async (req, res) => {
     const r = await validateDiscount(req.body.code, req.shop)
     if (r.discount) {
       r.discount = getSafeDiscountProps(r.discount)
@@ -14,7 +14,7 @@ module.exports = function (app) {
     res.json(r)
   })
 
-  app.get('/discounts', authSellerAndShop, async (req, res) => {
+  router.get('/discounts', authSellerAndShop, async (req, res) => {
     const discounts = await Discount.findAll({
       where: { shopId: req.shop.id },
       order: [['createdAt', 'desc']]
@@ -22,7 +22,7 @@ module.exports = function (app) {
     res.json(discounts)
   })
 
-  app.get('/discounts/:id', authSellerAndShop, async (req, res) => {
+  router.get('/discounts/:id', authSellerAndShop, async (req, res) => {
     const discount = await Discount.findOne({
       where: {
         id: req.params.id,
@@ -32,7 +32,7 @@ module.exports = function (app) {
     res.json(discount)
   })
 
-  app.post('/discounts', authSellerAndShop, async (req, res) => {
+  router.post('/discounts', authSellerAndShop, async (req, res) => {
     const discount = await Discount.create({
       ...req.body,
       shopId: req.shop.id
@@ -40,7 +40,7 @@ module.exports = function (app) {
     res.json({ success: true, discount })
   })
 
-  app.put('/discounts/:id', authSellerAndShop, async (req, res) => {
+  router.put('/discounts/:id', authSellerAndShop, async (req, res) => {
     const data = pick(req.body, [
       'status',
       'code',
@@ -72,7 +72,7 @@ module.exports = function (app) {
     res.json({ success: true, discount })
   })
 
-  app.delete('/discounts/:id', authSellerAndShop, async (req, res) => {
+  router.delete('/discounts/:id', authSellerAndShop, async (req, res) => {
     const discount = await Discount.destroy({
       where: {
         id: req.params.id,

--- a/backend/routes/domains.js
+++ b/backend/routes/domains.js
@@ -11,8 +11,8 @@ const { Network } = require('../models')
 
 const log = getLogger('routes.domains')
 
-module.exports = function (app) {
-  app.post(
+module.exports = function (router) {
+  router.post(
     '/domains/verify-dns',
     authSellerAndShop,
     authRole('admin'),

--- a/backend/routes/health.js
+++ b/backend/routes/health.js
@@ -4,15 +4,15 @@ const { getLogger } = require('../utils/logger')
 
 const log = getLogger('routes.health')
 
-module.exports = function (app) {
+module.exports = function (router) {
   // This endpoint will tell the health checks that this backend has started
-  app.get('/health/started', async (req, res) => {
+  router.get('/health/started', async (req, res) => {
     res.json({ success: true })
   })
 
   // This will do some basic connection health checks to determine the health
   // of the backend.
-  app.get('/health/status', async (req, res) => {
+  router.get('/health/status', async (req, res) => {
     try {
       // Quick DB check. There should be at least one default network and this
       // should throw if the connection is bad.

--- a/backend/routes/networks.js
+++ b/backend/routes/networks.js
@@ -22,8 +22,8 @@ function pickConfig(body) {
   ])
 }
 
-module.exports = function (app) {
-  app.post('/networks', authSuperUser, async (req, res) => {
+module.exports = function (router) {
+  router.post('/networks', authSuperUser, async (req, res) => {
     const networkObj = {
       networkId: req.body.networkId,
       provider: req.body.provider,
@@ -52,7 +52,7 @@ module.exports = function (app) {
     res.json({ success: true })
   })
 
-  app.get('/networks/:netId', authSuperUser, async (req, res) => {
+  router.get('/networks/:netId', authSuperUser, async (req, res) => {
     const where = { networkId: req.params.netId }
     const network = await Network.findOne({ where })
     if (!network) {
@@ -63,7 +63,7 @@ module.exports = function (app) {
     res.json({ ...omit(network.dataValues, 'config'), ...config })
   })
 
-  app.put('/networks/:netId', authSuperUser, async (req, res) => {
+  router.put('/networks/:netId', authSuperUser, async (req, res) => {
     const where = { networkId: req.params.netId }
     const network = await Network.findOne({ where })
     if (!network) {
@@ -87,20 +87,24 @@ module.exports = function (app) {
     res.json({ success: true })
   })
 
-  app.post('/networks/:netId/make-active', authSuperUser, async (req, res) => {
-    const where = { networkId: req.params.netId }
-    const network = await Network.findOne({ where })
-    if (!network) {
-      return res.json({ success: false, reason: 'no-network' })
+  router.post(
+    '/networks/:netId/make-active',
+    authSuperUser,
+    async (req, res) => {
+      const where = { networkId: req.params.netId }
+      const network = await Network.findOne({ where })
+      if (!network) {
+        return res.json({ success: false, reason: 'no-network' })
+      }
+
+      await Network.update({ active: false }, { where: {} })
+      const result = await Network.update({ active: true }, { where })
+
+      if (!result || result[0] < 1) {
+        return res.json({ success: false })
+      }
+
+      res.json({ success: true })
     }
-
-    await Network.update({ active: false }, { where: {} })
-    const result = await Network.update({ active: true }, { where })
-
-    if (!result || result[0] < 1) {
-      return res.json({ success: false })
-    }
-
-    res.json({ success: true })
-  })
+  )
 }

--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -4,8 +4,8 @@ const { findOrder } = require('../utils/orders')
 const makeOffer = require('./_makeOffer')
 const { sendNewOrderEmail } = require('../utils/emailer')
 
-module.exports = function (app) {
-  app.get('/orders', authSellerAndShop, async (req, res) => {
+module.exports = function (router) {
+  router.get('/orders', authSellerAndShop, async (req, res) => {
     const orders = await Order.findAll({
       where: { shopId: req.shop.id },
       order: [['createdAt', 'desc']]
@@ -13,11 +13,11 @@ module.exports = function (app) {
     res.json(orders)
   })
 
-  app.get('/orders/:orderId', authSellerAndShop, findOrder, (req, res) => {
+  router.get('/orders/:orderId', authSellerAndShop, findOrder, (req, res) => {
     res.json(req.order)
   })
 
-  app.post(
+  router.post(
     '/orders/:orderId/email',
     authSellerAndShop,
     findOrder,
@@ -31,7 +31,7 @@ module.exports = function (app) {
     }
   )
 
-  app.post(
+  router.post(
     '/orders/create',
     authSellerAndShop,
     (req, res, next) => {

--- a/backend/routes/printful.js
+++ b/backend/routes/printful.js
@@ -15,11 +15,11 @@ const log = getLogger('routes.printful')
 
 const { ExternalEvent } = require('../models')
 
-module.exports = function (app) {
+module.exports = function (router) {
   /**
    * Makes an API call to Printful to get details about a specific order.
    */
-  app.get(
+  router.get(
     '/orders/:orderId/printful',
     authSellerAndShop,
     findOrder,
@@ -34,7 +34,7 @@ module.exports = function (app) {
     }
   )
 
-  app.post(
+  router.post(
     '/orders/:orderId/printful/create',
     authSellerAndShop,
     async (req, res) => {
@@ -46,7 +46,7 @@ module.exports = function (app) {
     }
   )
 
-  app.post(
+  router.post(
     '/orders/:orderId/printful/confirm',
     authSellerAndShop,
     findOrder,
@@ -58,7 +58,7 @@ module.exports = function (app) {
     }
   )
 
-  app.post('/shipping', authShop, async (req, res) => {
+  router.post('/shipping', authShop, async (req, res) => {
     // console.log(req.body)
     const apiKey = await encConf.get(req.shop.id, 'printful')
     const { status, ...resp } = await fetchShippingEstimate(apiKey, req.body)
@@ -66,7 +66,7 @@ module.exports = function (app) {
     return res.status(status || 200).send(resp)
   })
 
-  app.post('/printful/webhooks/:shopId/:secret', async (req, res) => {
+  router.post('/printful/webhooks/:shopId/:secret', async (req, res) => {
     const { type, data } = req.body
     const { shopId, secret } = req.params
 

--- a/backend/routes/products.js
+++ b/backend/routes/products.js
@@ -9,8 +9,8 @@ const { getLogger } = require('../utils/logger')
 
 const log = getLogger('routes.products')
 
-module.exports = function (app) {
-  app.post(
+module.exports = function (router) {
+  router.post(
     '/products',
     authSellerAndShop,
     authRole('admin'),
@@ -31,7 +31,7 @@ module.exports = function (app) {
     }
   )
 
-  app.delete(
+  router.delete(
     '/products/:productId',
     authSellerAndShop,
     authRole('admin'),
@@ -55,7 +55,7 @@ module.exports = function (app) {
     }
   )
 
-  app.post(
+  router.post(
     '/products/upload-images',
     authSellerAndShop,
     authRole('admin'),

--- a/backend/routes/shipping-zones.js
+++ b/backend/routes/shipping-zones.js
@@ -6,8 +6,8 @@ const snakeCase = require('lodash/snakeCase')
 const { authSellerAndShop, authRole } = require('./_auth')
 const { DSHOP_CACHE } = require('../utils/const')
 
-module.exports = function (app) {
-  app.put(
+module.exports = function (router) {
+  router.put(
     '/shipping-zones',
     authSellerAndShop,
     authRole('admin'),
@@ -35,7 +35,7 @@ module.exports = function (app) {
     }
   )
 
-  app.put(
+  router.put(
     '/shipping-zones/:shippingId',
     authSellerAndShop,
     authRole('admin'),

--- a/backend/routes/shops.js
+++ b/backend/routes/shops.js
@@ -44,8 +44,8 @@ const printfulSyncProcessor = require('../queues/printfulSyncProcessor')
 
 const log = getLogger('routes.shops')
 
-module.exports = function (app) {
-  app.get(
+module.exports = function (router) {
+  router.get(
     '/shop/users',
     authSellerAndShop,
     authRole('admin'),
@@ -72,7 +72,7 @@ module.exports = function (app) {
     }
   )
 
-  app.get('/shop', async (req, res) => {
+  router.get('/shop', async (req, res) => {
     const { sellerId } = req.session
 
     if (!sellerId) {
@@ -93,7 +93,7 @@ module.exports = function (app) {
     res.json({ success: true, shops })
   })
 
-  app.post(
+  router.post(
     '/shop/sync-printful',
     authSellerAndShop,
     authRole('admin'),
@@ -124,7 +124,7 @@ module.exports = function (app) {
     }
   )
 
-  app.get('/shops/:shopId/deployments', authSuperUser, async (req, res) => {
+  router.get('/shops/:shopId/deployments', authSuperUser, async (req, res) => {
     const shop = await Shop.findOne({ where: { authToken: req.params.shopId } })
     if (!shop) {
       return res.json({ success: false, reason: 'no-such-shop' })
@@ -158,7 +158,7 @@ module.exports = function (app) {
     res.json({ deployments })
   })
 
-  app.get('/shops/:shopId/assets', authSuperUser, async (req, res) => {
+  router.get('/shops/:shopId/assets', authSuperUser, async (req, res) => {
     const shop = await Shop.findOne({ where: { authToken: req.params.shopId } })
     if (!shop) {
       return res.json({ success: false, reason: 'no-such-shop' })
@@ -172,7 +172,7 @@ module.exports = function (app) {
     })
   })
 
-  app.delete('/shops/:shopId/assets', authSuperUser, async (req, res) => {
+  router.delete('/shops/:shopId/assets', authSuperUser, async (req, res) => {
     const shop = await Shop.findOne({ where: { authToken: req.params.shopId } })
     if (!shop) {
       return res.json({ success: false, reason: 'no-such-shop' })
@@ -191,7 +191,7 @@ module.exports = function (app) {
     })
   })
 
-  app.post('/shops/:shopId/sync-cache', authSuperUser, async (req, res) => {
+  router.post('/shops/:shopId/sync-cache', authSuperUser, async (req, res) => {
     const shop = await Shop.findOne({ where: { authToken: req.params.shopId } })
     if (!shop) {
       return res.json({ success: false, reason: 'no-such-shop' })
@@ -283,7 +283,7 @@ module.exports = function (app) {
   /**
    * Creates a new shop.
    */
-  app.post('/shop', authUser, async (req, res) => {
+  router.post('/shop', authUser, async (req, res) => {
     const { dataDir, printfulApi, shopType, backend, hostname } = req.body
     const OutputDir = `${DSHOP_CACHE}/${dataDir}`
 
@@ -481,7 +481,7 @@ module.exports = function (app) {
     return res.json({ success: true, slug: dataDir })
   })
 
-  app.post(
+  router.post(
     '/shops/:shopId/save-files',
     authSuperUser,
     async (req, res, next) => {
@@ -531,7 +531,7 @@ module.exports = function (app) {
     }
   )
 
-  app.put(
+  router.put(
     '/shop/assets',
     authSellerAndShop,
     authRole('admin'),
@@ -599,7 +599,7 @@ module.exports = function (app) {
     }
   )
 
-  app.put(
+  router.put(
     '/shop/social-links',
     authSellerAndShop,
     authRole('admin'),
@@ -721,7 +721,7 @@ module.exports = function (app) {
     }
   }
 
-  app.put(
+  router.put(
     '/shop/config',
     authSellerAndShop,
     authRole('admin'),
@@ -837,7 +837,7 @@ module.exports = function (app) {
     }
   )
 
-  app.post(
+  router.post(
     '/shop/add-user',
     authSellerAndShop,
     authRole('admin'),
@@ -884,7 +884,7 @@ module.exports = function (app) {
     }
   )
 
-  app.delete('/shops/:shopId', authSuperUser, async (req, res) => {
+  router.delete('/shops/:shopId', authSuperUser, async (req, res) => {
     try {
       const shop = await Shop.findOne({
         where: { authToken: req.params.shopId }
@@ -915,7 +915,7 @@ module.exports = function (app) {
   /**
    * Called by super-admin for deploying a shop.
    */
-  app.post('/shops/:shopId/deploy', authSuperUser, async (req, res) => {
+  router.post('/shops/:shopId/deploy', authSuperUser, async (req, res) => {
     const shop = await Shop.findOne({ where: { authToken: req.params.shopId } })
     if (!shop) {
       return res.json({ success: false, reason: 'shop-not-found' })
@@ -949,7 +949,7 @@ module.exports = function (app) {
   /**
    * Called by admin for deploying a shop.
    */
-  app.post(
+  router.post(
     '/shop/deploy',
     authSellerAndShop,
     authRole('admin'),
@@ -1013,7 +1013,7 @@ module.exports = function (app) {
     }
   )
 
-  app.get(
+  router.get(
     '/shop/deployments',
     authSellerAndShop,
     authRole('admin'),
@@ -1050,7 +1050,7 @@ module.exports = function (app) {
   /**
    * Create a shop deployment record
    */
-  app.post(
+  router.post(
     '/shops/:shopId/create-deployment',
     authSellerAndShop,
     authRole('admin'),
@@ -1090,7 +1090,7 @@ module.exports = function (app) {
   /**
    * Get names (DNS names, crypto names, etc) for a shop
    */
-  app.get(
+  router.get(
     '/shops/:shopId/get-names',
     authSellerAndShop,
     authRole('admin'),
@@ -1127,7 +1127,7 @@ module.exports = function (app) {
   /**
    * Set names (DNS names, crypto names, etc) for a shop deployment
    */
-  app.post(
+  router.post(
     '/shops/:shopId/set-names',
     authSellerAndShop,
     authRole('admin'),

--- a/backend/routes/stripe.js
+++ b/backend/routes/stripe.js
@@ -23,8 +23,8 @@ const rawJson = bodyParser.raw({ type: 'application/json' })
 //    stripe listen --forward-to localhost:3000/webhook
 // Update stripe webhook in shop server config
 
-module.exports = function (app) {
-  app.post('/pay', authShop, async (req, res) => {
+module.exports = function (router) {
+  router.post('/pay', authShop, async (req, res) => {
     if (req.body.amount < 50) {
       return res.status(400).send({
         success: false,
@@ -146,9 +146,9 @@ module.exports = function (app) {
     next()
   }
 
-  app.post('/webhook', rawJson, handleWebhook, makeOffer)
+  router.post('/webhook', rawJson, handleWebhook, makeOffer)
 
-  app.post('/stripe/check-creds', authShop, async (req, res) => {
+  router.post('/stripe/check-creds', authShop, async (req, res) => {
     let valid = false
 
     try {

--- a/backend/routes/tx.js
+++ b/backend/routes/tx.js
@@ -2,22 +2,27 @@ const { Event, Transaction } = require('../models')
 const { authSellerAndShop, authRole } = require('./_auth')
 const pick = require('lodash/pick')
 
-module.exports = function (app) {
-  app.get('/events', authSellerAndShop, authRole('admin'), async (req, res) => {
-    const events = await Event.findAll({
-      where: { shopId: req.shop.id }
-    })
-    res.json(events)
-  })
+module.exports = function (router) {
+  router.get(
+    '/events',
+    authSellerAndShop,
+    authRole('admin'),
+    async (req, res) => {
+      const events = await Event.findAll({
+        where: { shopId: req.shop.id }
+      })
+      res.json(events)
+    }
+  )
 
-  app.get('/transactions', authSellerAndShop, async (req, res) => {
+  router.get('/transactions', authSellerAndShop, async (req, res) => {
     const transactions = await Transaction.findAll({
       where: { shopId: req.shop.id }
     })
     res.json(transactions)
   })
 
-  app.get('/events/:txId', (req, res) => {
+  router.get('/events/:txId', (req, res) => {
     const where = { transactionHash: req.params.txId }
     Event.findOne({ where }).then((event) => {
       res.json(pick(event, 'ipfsHash', 'transactionHash'))

--- a/backend/routes/uphold.js
+++ b/backend/routes/uphold.js
@@ -22,8 +22,8 @@ const UpholdEndpoints = {
   }
 }
 
-module.exports = function (app) {
-  app.get('/uphold/authed', authShop, async (req, res) => {
+module.exports = function (router) {
+  router.get('/uphold/authed', authShop, async (req, res) => {
     const { upholdApi } = getConfig(req.shop.config)
     if (!UpholdEndpoints[upholdApi]) {
       return res.json({ authed: false, message: 'Uphold not configured' })
@@ -57,7 +57,7 @@ module.exports = function (app) {
     })
   })
 
-  app.get('/uphold/auth-response', async (req, res) => {
+  router.get('/uphold/auth-response', async (req, res) => {
     const { upholdAuth } = req.session
     const { code, state } = req.query
     if (!upholdAuth) {
@@ -106,7 +106,7 @@ module.exports = function (app) {
     res.send(`<script>window.opener.postMessage('ok', '*')</script>OK`)
   })
 
-  app.get('/uphold/cards', authShop, async (req, res) => {
+  router.get('/uphold/cards', authShop, async (req, res) => {
     const { upholdApi } = getConfig(req.shop.config)
     if (!UpholdEndpoints[upholdApi]) {
       return res.json({ success: false, message: 'Uphold not configured' })
@@ -143,7 +143,7 @@ module.exports = function (app) {
   })
 
   // body: { amount, listingId, data }
-  app.post(
+  router.post(
     '/uphold/pay',
     authShop,
     async (req, res, next) => {
@@ -193,7 +193,7 @@ module.exports = function (app) {
     makeOffer
   )
 
-  app.post('/uphold/logout', authShop, (req, res) => {
+  router.post('/uphold/logout', authShop, (req, res) => {
     req.session.upholdAccessToken = null
     req.session.upholdAuth = null
     req.session.save(function () {

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -17,14 +17,14 @@ const { getLogger } = require('../utils/logger')
 
 const log = getLogger('routes.users')
 
-module.exports = function (app) {
-  app.get('/superuser/users', authSuperUser, async (req, res) => {
+module.exports = function (router) {
+  router.get('/superuser/users', authSuperUser, async (req, res) => {
     Seller.findAll().then((users) => {
       res.json({ users })
     })
   })
 
-  app.get('/superuser/users/:userId', authSuperUser, async (req, res) => {
+  router.get('/superuser/users/:userId', authSuperUser, async (req, res) => {
     Seller.findOne({
       where: { id: req.params.userId },
       include: Shop
@@ -41,7 +41,7 @@ module.exports = function (app) {
     })
   })
 
-  app.put('/superuser/users/:userId', authSuperUser, async (req, res) => {
+  router.put('/superuser/users/:userId', authSuperUser, async (req, res) => {
     const user = await Seller.findOne({ where: { id: req.params.userId } })
     if (!user) {
       return res.json({ success: false, reason: 'no-such-user' })
@@ -69,7 +69,7 @@ module.exports = function (app) {
     res.json({ success: true })
   })
 
-  app.post('/superuser/users', authSuperUser, async (req, res) => {
+  router.post('/superuser/users', authSuperUser, async (req, res) => {
     createSeller(req.body, {
       superuser: req.body.superuser,
       skipEmailVerification: true
@@ -78,7 +78,7 @@ module.exports = function (app) {
     })
   })
 
-  app.delete('/superuser/users/:userId', authSuperUser, async (req, res) => {
+  router.delete('/superuser/users/:userId', authSuperUser, async (req, res) => {
     const { userId } = req.params
     if (String(userId) === String(req.session.sellerId)) {
       return res.json({ success: false, reason: 'cannot-delete-self' })
@@ -95,7 +95,7 @@ module.exports = function (app) {
       .catch((err) => res.json({ success: false, reason: err.toString() }))
   })
 
-  app.get('/verify-email', async (req, res) => {
+  router.get('/verify-email', async (req, res) => {
     const { code } = req.query
     const seller = await Seller.findOne({
       where: {
@@ -122,7 +122,7 @@ module.exports = function (app) {
     res.send(resp)
   })
 
-  app.put('/resend-email', authSellerAndShop, async (req, res) => {
+  router.put('/resend-email', authSellerAndShop, async (req, res) => {
     let sent = false
 
     try {

--- a/backend/sentry.js
+++ b/backend/sentry.js
@@ -1,0 +1,13 @@
+const Sentry = require('@sentry/node')
+const sentryEventPrefix =
+  'https://sentry.io/organizations/origin-protocol/projects/squad-deals-api/events'
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.ENVIRONMENT || 'development'
+})
+
+module.exports = {
+  Sentry,
+  sentryEventPrefix
+}

--- a/backend/sentry.js
+++ b/backend/sentry.js
@@ -1,6 +1,6 @@
 const Sentry = require('@sentry/node')
 const sentryEventPrefix =
-  'https://sentry.io/organizations/origin-protocol/projects/squad-deals-api/events'
+  'https://sentry.io/organizations/origin-protocol/projects/dshop-backend/events'
 
 const { getLogger } = require('./utils/logger')
 const log = getLogger('sentry')

--- a/backend/sentry.js
+++ b/backend/sentry.js
@@ -2,10 +2,22 @@ const Sentry = require('@sentry/node')
 const sentryEventPrefix =
   'https://sentry.io/organizations/origin-protocol/projects/squad-deals-api/events'
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  environment: process.env.ENVIRONMENT || 'development'
-})
+const { getLogger } = require('./utils/logger')
+const log = getLogger('sentry')
+
+const dsn = process.env.SENTRY_DSN
+const environment = process.env.ENVIRONMENT || 'development'
+
+if (dsn) {
+  log.info(`Initializing Sentry with environment: ${environment}`)
+  Sentry.init({ dsn, environment })
+} else {
+  if (environment === 'development') {
+    log.info('Skipping Sentry initialization')
+  } else {
+    log.error('Sentry initialization failed. SENTRY_DSN is not defined.')
+  }
+}
 
 module.exports = {
   Sentry,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,6 +2729,85 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@sentry/apm@5.19.2":
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.19.2.tgz#369fdcbc9fa5db992f707b24f3165e106a277cf7"
+  integrity sha512-V7p5niqG/Nn1OSMAyreChiIrQFYzFHKADKNaDEvIXqC4hxFnMG8lPRqEFJH49fNjsFBFfIG9iY1rO1ZFg3S42Q==
+  dependencies:
+    "@sentry/browser" "5.19.2"
+    "@sentry/hub" "5.19.2"
+    "@sentry/minimal" "5.19.2"
+    "@sentry/types" "5.19.2"
+    "@sentry/utils" "5.19.2"
+    tslib "^1.9.3"
+
+"@sentry/browser@5.19.2":
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.19.2.tgz#8bad445b8d1efd50e6510bb43b3018b941f6e5cb"
+  integrity sha512-o6Z532n+0N5ANDzgR9GN+Q6CU7zVlIJvBEW234rBiB+ZZj6XwTLS1dD+JexGr8lCo8PeXI2rypKcj1jUGLVW8w==
+  dependencies:
+    "@sentry/core" "5.19.2"
+    "@sentry/types" "5.19.2"
+    "@sentry/utils" "5.19.2"
+    tslib "^1.9.3"
+
+"@sentry/core@5.19.2":
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.19.2.tgz#99a64ef0e55230fc02a083c48fa07ada85de4929"
+  integrity sha512-sfbBsVXpA0WYJUichz5IhvqKD8xJUfQvsszrTsUKa7PQAMAboOmuh6bo8KquaVQnAZyZWZU08UduvlSV3tA7tw==
+  dependencies:
+    "@sentry/hub" "5.19.2"
+    "@sentry/minimal" "5.19.2"
+    "@sentry/types" "5.19.2"
+    "@sentry/utils" "5.19.2"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.19.2":
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.19.2.tgz#ab7f3d2d253c3441b2833a530b17c6de2418b2c7"
+  integrity sha512-2KkEYX4q9TDCOiaVEo2kQ1W0IXyZxJxZtIjDdFQyes9T4ubYlKHAbvCjTxHSQv37lDO4t7sOIApWG9rlkHzlEA==
+  dependencies:
+    "@sentry/types" "5.19.2"
+    "@sentry/utils" "5.19.2"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.19.2":
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.19.2.tgz#0fc2fdf9911a0cb31b52f7ccad061b74785724a3"
+  integrity sha512-rApEOkjy+ZmkeqEItgFvUFxe5l+dht9AumuUzq74pWp+HJqxxv9IVTusKppBsE1adjtmyhwK4O3Wr8qyc75xlw==
+  dependencies:
+    "@sentry/hub" "5.19.2"
+    "@sentry/types" "5.19.2"
+    tslib "^1.9.3"
+
+"@sentry/node@^5.19.2":
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.19.2.tgz#8c1c2f6c983c3d8b25143e5b99c4b6cc745125ec"
+  integrity sha512-gbww3iTWkdvYIAhOmULbv8znKwkIpklGJ0SPtAh0orUMuaa0lVht+6HQIhRgeXp50lMzNaYC3fuzkbFfYgpS7A==
+  dependencies:
+    "@sentry/apm" "5.19.2"
+    "@sentry/core" "5.19.2"
+    "@sentry/hub" "5.19.2"
+    "@sentry/types" "5.19.2"
+    "@sentry/utils" "5.19.2"
+    cookie "^0.3.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/types@5.19.2":
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.19.2.tgz#ead586f0b64b91c396d3521b938ca25f7b59d655"
+  integrity sha512-O6zkW8oM1qK5Uma9+B/UMlmlm9/gkw9MooqycWuEhIaKfDBj/yVbwb/UTiJmNkGc5VJQo0v1uXUZZQt6/Xq1GA==
+
+"@sentry/utils@5.19.2":
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.19.2.tgz#f2819d9de5abc33173019e81955904247e4a8246"
+  integrity sha512-gEPkC0CJwvIWqcTcPSdIzqJkJa9N5vZzUZyBvdu1oiyJu7MfazpJEvj3whfJMysSfXJQxoJ+a1IPrA73VY23VA==
+  dependencies:
+    "@sentry/types" "5.19.2"
+    tslib "^1.9.3"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -6644,7 +6723,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.3.1:
+cookie@0.3.1, cookie@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
@@ -14740,6 +14819,11 @@ lru-queue@0.1:
   dependencies:
     es5-ext "~0.10.2"
 
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
+
 ltgt@^2.1.2, ltgt@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
@@ -21985,7 +22069,7 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
-tslib@^1.10.0, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9347,6 +9347,15 @@ express-async-router@^0.1.15:
     "@types/node" "^8.10.36"
     express "^4.16.4"
 
+express-promise-router@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/express-promise-router/-/express-promise-router-4.0.1.tgz#7ed65473a12208ec1065c1358c398175b89d425c"
+  integrity sha512-kqan6QuMV7FdfN9b2uYpaKEJnxzfj57voI4IsMjgug5mBc6/hjuvoUT76Z/pvRqID2isl/NygTUe8S2MH2trMg==
+  dependencies:
+    is-promise "^4.0.0"
+    lodash.flattendeep "^4.0.0"
+    methods "^1.0.0"
+
 express-session@^1.17.1:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.1.tgz#36ecbc7034566d38c8509885c044d461c11bf357"
@@ -12766,6 +12775,11 @@ is-promise@^2.1:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
+is-promise@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
+  integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
+
 is-promise@~1, is-promise@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-1.0.1.tgz#31573761c057e33c2e91aab9e96da08cefbe76e5"
@@ -14588,6 +14602,11 @@ lodash.flatten@^4.2.0, lodash.flatten@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
+lodash.flattendeep@^4.0.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
 lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
@@ -15228,7 +15247,7 @@ messageformat@^2.2.1:
     messageformat-formatters "^2.0.1"
     messageformat-parser "^4.1.2"
 
-methods@^1.1.1, methods@~1.1.2:
+methods@^1.0.0, methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=


### PR DESCRIPTION
Integrate with Sentry to capture:
 - API server errors
 - Listener errors

Refactored the API server to use https://github.com/express-promise-router.
This now sends uncaught exceptions thrown within any route to the custom error handler and also properly sends a 500 error back. Before this change, the exceptions were not caught (Express 4 does not do it automatically) and that would cause the server to not return any response (e.g. the front-end would hang waiting for a response ).
