### PR TITLE
[Email verification] Redirect to back-end vs front-end URL

### DIFF
--- a/backend/utils/emailVerification.js
+++ b/backend/utils/emailVerification.js
@@ -1,4 +1,4 @@
-const generateVerificationCode = (backendUrl, publicUrl) => {
+const generateVerificationCode = (backendUrl) => {
   const code = Math.random().toString(36).substring(2)
   const expires = Date.now() + 24 * 60 * 60 * 1000 // 24 hours
 

--- a/backend/utils/emailVerification.js
+++ b/backend/utils/emailVerification.js
@@ -9,7 +9,7 @@ const generateVerificationCode = (backendUrl, publicUrl) => {
     code,
     expires,
     verifyUrl: verifyUrl.toString(),
-    redirectTo: publicUrl
+    redirectTo: backendUrl
   }
 }
 

--- a/backend/utils/sellers.js
+++ b/backend/utils/sellers.js
@@ -21,14 +21,13 @@ async function sendVerificationEmail(seller, shopId) {
   })
 
   const networkConfig = getConfig(network.config)
-  const shopConfig = getConfig(shop.config)
-
-  const publicUrl = get(shopConfig, 'publicUrl', '')
-  const backendUrl = get(networkConfig, 'backendUrl', '')
+  const backendUrl = get(networkConfig, 'backendUrl')
+  if (!backendUrl) {
+    throw new Error('backendUrl missing from network config')
+  }
 
   const { code, expires, verifyUrl, redirectTo } = generateVerificationCode(
-    backendUrl,
-    publicUrl
+    backendUrl
   )
 
   await seller.update({


### PR DESCRIPTION
To fix an issue where if an admin has not deployed their shop yet the email verification flow would fail.