### PR TITLE
Fixes dnslink TXT record

### DIFF
--- a/shop/src/pages/admin/settings/appearance/_CustomDomain.js
+++ b/shop/src/pages/admin/settings/appearance/_CustomDomain.js
@@ -89,10 +89,10 @@ const CustomDomain = ({ netId, hostname = '' }) => {
                     'network.ipfs',
                     ''
                   ).replace(/^https?:\/\//, '')}`}</div>
-                  <div className="record">{`_dnslink.${domain} TXT ${hostname}.${get(
+                  <div className="record">{`_dnslink.${domain} TXT "dnslink=/ipns/${hostname}.${get(
                     admin,
                     'network.domain'
-                  )}`}</div>
+                  )}"`}</div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
The custom domain DNS record instructions were incorrect for the DNSLink records.

Should be like the following:

    example.domain.com  CNAME fs-autossl.ogn.app
    _dnslink.example.domain.com  TXT "dnslink=/ipns/example.ogn.app"

These were tested and confirmed.