### PR TITLE
DNS Verification Fixen

### DIFF
--- a/backend/routes/domains.js
+++ b/backend/routes/domains.js
@@ -49,8 +49,7 @@ module.exports = function (router) {
               [Op.like]: `%${domain}%`
             }
           },
-          order: [['created_at', 'DESC']],
-          limit: 1
+          order: [['created_at', 'DESC']]
         })
 
         if (!deployment) {

--- a/backend/routes/domains.js
+++ b/backend/routes/domains.js
@@ -1,12 +1,10 @@
 const fetch = require('node-fetch')
-
 const get = require('lodash/get')
 
-const { authSellerAndShop, authRole } = require('./_auth')
-
 const { getLogger } = require('../utils/logger')
-
 const { Op, Network, ShopDeployment } = require('../models')
+
+const { authSellerAndShop, authRole } = require('./_auth')
 
 const log = getLogger('routes.domains')
 

--- a/backend/routes/domains.js
+++ b/backend/routes/domains.js
@@ -5,11 +5,13 @@ const get = require('lodash/get')
 const { authSellerAndShop, authRole } = require('./_auth')
 
 const { getLogger } = require('../utils/logger')
-const { getConfig } = require('../utils/encryptedConfig')
 
-const { Network } = require('../models')
+const { Op, Network, ShopDeployment } = require('../models')
 
 const log = getLogger('routes.domains')
+
+// eslint-disable-next-line no-useless-escape
+const DNS_VALID = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/
 
 module.exports = function (router) {
   router.post(
@@ -21,23 +23,51 @@ module.exports = function (router) {
 
       log.debug('Trying to verify DNS records of domain', domain, hostname)
 
+      // Verify the domain is RFC-valid
+      if (!domain.match(DNS_VALID)) {
+        log.debug(`${domain} is not a valid domain`)
+        return res.send({
+          success: true,
+          error: 'Invalid domain'
+        })
+      }
+
       try {
         const network = await Network.findOne({
           where: { networkId }
         })
 
         if (!network) {
-          return {
+          log.debug(`${networkId} is not a valid network for this node`)
+          return res.send({
             success: true,
             error: 'Invalid network ID'
-          }
+          })
         }
 
-        const networkConfig = getConfig(network.config)
+        const deployment = await ShopDeployment.findOne({
+          where: {
+            domain: {
+              [Op.like]: `%${domain}%`
+            }
+          },
+          order: [['created_at', 'DESC']],
+          limit: 1
+        })
+
+        if (!deployment) {
+          log.debug(`${domain} has no deployments`)
+          return res.send({
+            success: true,
+            error: 'No deployments'
+          })
+        }
 
         const ipfsURL = `${network.ipfsApi}/api/v0/dns?arg=${encodeURIComponent(
           domain
         )}`
+
+        log.debug(`Making request to ${ipfsURL}`)
 
         const r = await fetch(ipfsURL, {
           method: 'POST'
@@ -46,8 +76,8 @@ module.exports = function (router) {
         if (r.ok) {
           const respJson = await r.json()
 
-          const path = get(respJson, 'Path', '').toLowerCase()
-          const expectedValue = `/ipns/${hostname}.${networkConfig.domain}`.toLowerCase()
+          const path = get(respJson, 'Path', '')
+          const expectedValue = `/ipfs/${deployment.ipfsHash}`
 
           if (path === expectedValue) {
             return res.send({
@@ -65,7 +95,7 @@ module.exports = function (router) {
           error: `Your DNS changes haven't propagated yet.`
         })
       } catch (err) {
-        console.error('Failed to check DNS of domain', err)
+        log.error('Failed to check DNS of domain', err)
         res.send({
           error: 'Unknown error occured'
         })


### PR DESCRIPTION
Fixes a few issues with the `/domains/verify-dns` endpoint.  Primarily `/api/v0/dns` returns IPFS hashes, not IPNS names, and IPFS hashes are case-sensitive.  Addressed a few other issues while there.

Fixes #282