### PR TITLE
DNS Record Suggestions

### DIFF
--- a/backend/routes/domains.js
+++ b/backend/routes/domains.js
@@ -118,11 +118,11 @@ module.exports = function (router) {
     }
 
     // A gateway with an unusual port won't work for this
-    /*if (network.ipfs.includes(':')) {
-        log.warn('Invalid IFPS gateway. Cannot use as AutoSSL gateway')
-        success = false
-        error = 'Cannot use this IFPS gateway for DNS configuration'
-      }*/
+    if (network.ipfs.includes(':')) {
+      log.warn('Invalid IFPS gateway. Cannot use as AutoSSL gateway')
+      success = false
+      error = 'Cannot use this IFPS gateway for DNS configuration'
+    }
 
     // If success so far...
     if (success) {

--- a/backend/routes/domains.js
+++ b/backend/routes/domains.js
@@ -2,14 +2,12 @@ const fetch = require('node-fetch')
 const get = require('lodash/get')
 
 const { getLogger } = require('../utils/logger')
+const { dnsResolve, isValidDNSName, hasNS } = require('../utils/dns')
 const { Op, Network, ShopDeployment } = require('../models')
 
 const { authSellerAndShop, authRole } = require('./_auth')
 
 const log = getLogger('routes.domains')
-
-// eslint-disable-next-line no-useless-escape
-const DNS_VALID = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/
 
 module.exports = function (router) {
   router.post(
@@ -22,7 +20,7 @@ module.exports = function (router) {
       log.debug('Trying to verify DNS records of domain', domain, hostname)
 
       // Verify the domain is RFC-valid
-      if (!domain.match(DNS_VALID)) {
+      if (!isValidDNSName(domain)) {
         log.debug(`${domain} is not a valid domain`)
         return res.send({
           success: true,
@@ -99,4 +97,60 @@ module.exports = function (router) {
       }
     }
   )
+
+  router.post('/domains/records', authSellerAndShop, async (req, res) => {
+    const { domain, networkId } = req.body
+
+    let success = true
+    let error = ''
+    let rrtype = null
+    let rvalue = null
+    let isApex = false
+
+    const network = await Network.findOne({
+      where: { networkId }
+    })
+
+    if (!network) {
+      log.warning('Invalid network provided to /domains/records')
+      success = false
+      error = 'Invalid network'
+    }
+
+    // A gateway with an unusual port won't work for this
+    /*if (network.ipfs.includes(':')) {
+        log.warn('Invalid IFPS gateway. Cannot use as AutoSSL gateway')
+        success = false
+        error = 'Cannot use this IFPS gateway for DNS configuration'
+      }*/
+
+    // If success so far...
+    if (success) {
+      try {
+        isApex = await hasNS(domain)
+
+        if (isApex) {
+          const ipfsURL = new URL(network.ipfs)
+          const ips = await dnsResolve(ipfsURL.hostname, 'A')
+          rrtype = 'A'
+          rvalue = ips[0]
+        } else {
+          rrtype = 'CNAME'
+          rvalue = network.ipfs
+        }
+      } catch (err) {
+        log.error('Error checking DNS: ', err)
+        success = false
+        error = 'Lookup failed'
+      }
+    }
+
+    return res.send({
+      success,
+      error,
+      isApex,
+      rrtype,
+      rvalue
+    })
+  })
 }

--- a/backend/routes/domains.js
+++ b/backend/routes/domains.js
@@ -118,7 +118,7 @@ module.exports = function (router) {
     }
 
     // A gateway with an unusual port won't work for this
-    if (network.ipfs.includes(':')) {
+    if (network && network.ipfs.includes(':')) {
       log.warn('Invalid IFPS gateway. Cannot use as AutoSSL gateway')
       success = false
       error = 'Cannot use this IFPS gateway for DNS configuration'

--- a/backend/utils/dns/index.js
+++ b/backend/utils/dns/index.js
@@ -1,5 +1,13 @@
+const dns = require('dns')
+const fetch = require('node-fetch')
+
+const TLD_LIST_URL = 'https://data.iana.org/TLD/tlds-alpha-by-domain.txt'
 const UNSTOPPABLE_TLDS = ['crypto']
 const CRYPTO_DOMAINS = [...UNSTOPPABLE_TLDS]
+// eslint-disable-next-line no-useless-escape
+const DNS_VALID = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/
+
+let CACHED_TLDS = null
 
 /**
  * Is the given hostname a crypto name?
@@ -37,8 +45,131 @@ function isPublicDNSName(v) {
   )
 }
 
+/**
+ * Is the given hostname a valid DNS name
+ *
+ * @param v {string} - The string to check
+ * @returns {boolean} - if the given name is a valid DNS name
+ */
+function isValidDNSName(v) {
+  return v.match(DNS_VALID)
+}
+
+/**
+ * Fetch a TLD list from IANA and return an array of valid TLDs
+ *
+ * @returns {Array} - of valid TLDs in caps
+ */
+async function getTLDArray() {
+  const resp = await fetch(TLD_LIST_URL)
+
+  if (!resp.ok) {
+    throw new Error('Error getting TLD list from IANA')
+  }
+
+  const tldsText = await resp.text()
+  return tldsText.split('\n').filter((ln) => !ln.startsWith('#'))
+}
+
+/**
+ * Is the given string a valid TLD?
+ *
+ * @param v {string} - The string to check
+ * @returns {boolean} - if the given name is a valid TLD
+ */
+async function isValidTLD(v) {
+  if (!CACHED_TLDS) {
+    CACHED_TLDS = await getTLDArray()
+  }
+  return CACHED_TLDS.includes(v.toUpperCase())
+}
+
+/**
+ * Resolve a DNS record
+ *
+ * @param name {string} - The DNS name to lookup
+ * @returns {Promise<object|Error>} - The DNS record
+ */
+function dnsResolve(name, rrtype) {
+  return new Promise((resolve, reject) => {
+    dns.resolve(name, rrtype, (err, rec) => {
+      if (err) return reject(err)
+      resolve(rec)
+    })
+  })
+}
+
+/**
+ * Does the given name have SOA records?
+ *
+ * @param v {string} - The DNS name to check
+ * @returns {boolean} - if the given name has SOA records
+ */
+async function hasSOA(v) {
+  if (!isValidDNSName(v)) {
+    throw new Error('Invalid DNS name')
+  }
+  if (await isValidTLD(v)) {
+    throw new Error('A TLD is not a valid DNS name')
+  }
+
+  // If there's an SOA record this is the apex domain of a zone
+  try {
+    await dnsResolve(v, 'SOA')
+    return true
+  } catch (err) {
+    if (
+      !(
+        err.toString().includes('ENODATA') ||
+        err.toString().includes('EBADRESP') ||
+        err.toString().includes('ENOTFOUND')
+      )
+    ) {
+      throw err
+    }
+    return false
+  }
+}
+
+/**
+ * Does the given DNS name have NS records?  Is this a zone?
+ *
+ * @param v {string} - The name to check
+ * @returns {boolean} - if the given name is a DNS zone
+ */
+async function hasNS(v) {
+  if (!isValidDNSName(v)) {
+    throw new Error('Invalid DNS name')
+  }
+  if (await isValidTLD(v)) {
+    throw new Error('A TLD is not a valid DNS zone')
+  }
+
+  // If there's NS records this is the apex of a zone
+  try {
+    await dnsResolve(v, 'NS')
+    return true
+  } catch (err) {
+    if (
+      !(
+        err.toString().includes('ENODATA') ||
+        err.toString().includes('EBADRESP') ||
+        err.toString().includes('ENOTFOUND')
+      )
+    ) {
+      throw err
+    }
+    return false
+  }
+}
+
 module.exports = {
   isPublicDNSName,
   isUnsoppableName,
-  isCryptoName
+  isCryptoName,
+  isValidDNSName,
+  isValidTLD,
+  hasNS,
+  hasSOA,
+  dnsResolve
 }

--- a/shop/src/pages/admin/settings/appearance/_CustomDomain.js
+++ b/shop/src/pages/admin/settings/appearance/_CustomDomain.js
@@ -41,7 +41,7 @@ const CustomDomain = ({ netId, hostname = '' }) => {
 
   useEffect(() => {
     if (!domain) return
-    console.log('DOMAINNNN:', domain)
+
     if (isValidDNSName(domain)) {
       setDomainExists(true)
 

--- a/shop/src/pages/admin/settings/appearance/_CustomDomain.js
+++ b/shop/src/pages/admin/settings/appearance/_CustomDomain.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import get from 'lodash/get'
 
 import PlusIcon from 'components/icons/Plus'
@@ -6,12 +6,15 @@ import Modal from 'components/Modal'
 
 import useBackendApi from 'utils/useBackendApi'
 import useAutoFocus from 'utils/useAutoFocus'
+import { isValidDNSName } from 'utils/dns'
 import { useStateValue } from 'data/state'
 
 const CustomDomain = ({ netId, hostname = '' }) => {
   const [show, setShow] = useState()
   const [shouldClose, setShouldClose] = useState()
   const [domain, setDomain] = useState('')
+  const [domainExists, setDomainExists] = useState(false)
+  const [records, setRecords] = useState(false)
   const [verifyStatus, setVerifyStatus] = useState({})
   const { post } = useBackendApi({ authToken: true })
   const [{ admin }] = useStateValue()
@@ -19,6 +22,7 @@ const CustomDomain = ({ netId, hostname = '' }) => {
 
   const verifyDomain = async () => {
     if (verifyStatus.loading) return
+
     setVerifyStatus({ loading: true })
 
     try {
@@ -35,11 +39,37 @@ const CustomDomain = ({ netId, hostname = '' }) => {
     }
   }
 
+  useEffect(() => {
+    if (!domain) return
+    console.log('DOMAINNNN:', domain)
+    if (isValidDNSName(domain)) {
+      setDomainExists(true)
+
+      const networkId = Number(netId)
+      const body = JSON.stringify({ domain, networkId })
+
+      post('/domains/records', {
+        body
+      })
+        .then((res) => {
+          const { isApex, rrtype, rvalue } = res
+          setRecords({ isApex, rrtype, rvalue })
+        })
+        .catch((err) => {
+          console.error(err)
+          setVerifyStatus({ error: 'Something went wrong. Try again later.' })
+        })
+    } else {
+      setDomainExists(false)
+    }
+  }, [domain])
+
   const dnsLink = `dnslink=/ipns/${hostname}.${get(admin, 'network.domain')}`
   const txtRecord = `_dnslink.${domain} TXT "${dnsLink}"`
 
-  const ipfsGateway = get(admin, 'network.ipfs', '').replace(/^https?:\/\//, '')
-  const cnameRecord = `${domain} CNAME ${ipfsGateway}`
+  const record = records
+    ? `${domain} ${records.rrtype} ${records.rvalue}`
+    : null
 
   return (
     <>
@@ -77,9 +107,13 @@ const CustomDomain = ({ netId, hostname = '' }) => {
               </div>
               {!domain ? null : (
                 <div className="records">
-                  <div>Please set the following DNS records:</div>
-                  <div className="record">{cnameRecord}</div>
-                  <div className="record">{txtRecord}</div>
+                  {!domainExists ? null : (
+                    <>
+                      <div>Please set the following DNS records:</div>
+                      <div className="record">{record}</div>
+                      <div className="record">{txtRecord}</div>
+                    </>
+                  )}
                 </div>
               )}
             </div>

--- a/shop/src/utils/dns.js
+++ b/shop/src/utils/dns.js
@@ -1,5 +1,7 @@
 const UNSTOPPABLE_TLDS = ['crypto']
 const CRYPTO_TLDS = [...UNSTOPPABLE_TLDS]
+// eslint-disable-next-line no-useless-escape
+const DNS_VALID = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/
 
 /**
  * Is the given hostname an unstoppable domain name?
@@ -39,4 +41,14 @@ export function isPublicDNSName(v) {
   return (
     !isCryptoName(v) && typeof v === 'string' && v.length > 3 && v.includes('.')
   )
+}
+
+/**
+ * Is the given hostname a valid DNS name
+ *
+ * @param v {string} - The string to check
+ * @returns {boolean} - if the given name is a valid DNS name
+ */
+export function isValidDNSName(v) {
+  return v.includes('.') && v.match(DNS_VALID)
 }


### PR DESCRIPTION
DNS record suggestions were invalid for root-zone records(e.g. originprotocol.com).  This tries to mitigate that by suggesting the user create an A record for their shop when necessary.  If that IP changes we're in for a ton of hassle but I don't see us dropping that if we have a choice in the near future.  And this is better than preventing users from using root-zone records entirely.

This PR touches both the FE and BE.

Fixes #289