### PR TITLE
Prevent concurrent deployments

### DIFF
--- a/backend/db/migrations/20200727184749-addStatusToShopDeployments.js
+++ b/backend/db/migrations/20200727184749-addStatusToShopDeployments.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const { ShopDeploymentStatuses } = require('../../enums')
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async () => {
+      await queryInterface.addColumn('shop_deployments', 'status', { type: Sequelize.ENUM(ShopDeploymentStatuses) })
+      await queryInterface.addColumn('shop_deployments', 'error', { type: Sequelize.STRING })
+    })
+  },
+  down: (queryInterface) => {
+    return queryInterface.sequelize.transaction(async () => {
+      await queryInterface.removeColumn('shop_deployments', 'error')
+      await queryInterface.removeColumn('shop_deployments', 'status')
+      await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_shop_deployments_status";')
+    })
+  }
+}

--- a/backend/enums.js
+++ b/backend/enums.js
@@ -17,7 +17,7 @@ const TransactionStatuses = new Enum('Pending', 'Confirmed', 'Failed')
 
 const TransactionTypes = new Enum('OfferCreated')
 
-const ShopDeploymentStatuses = new Enum('Pending', 'Success', 'Failed')
+const ShopDeploymentStatuses = new Enum('Pending', 'Success', 'Failure')
 
 module.exports = {
   TransactionStatuses,

--- a/backend/enums.js
+++ b/backend/enums.js
@@ -17,7 +17,10 @@ const TransactionStatuses = new Enum('Pending', 'Confirmed', 'Failed')
 
 const TransactionTypes = new Enum('OfferCreated')
 
+const ShopDeploymentStatuses = new Enum('Pending', 'Success', 'Failed')
+
 module.exports = {
   TransactionStatuses,
-  TransactionTypes
+  TransactionTypes,
+  ShopDeploymentStatuses
 }

--- a/backend/models/shop_deployment.js
+++ b/backend/models/shop_deployment.js
@@ -9,7 +9,8 @@ module.exports = (sequelize, DataTypes) => {
       domain: DataTypes.STRING, // Depreciated.  should be added to shop_deployment_names
       ipfsPinner: DataTypes.STRING, // URL of the IPFS pinner service used for the deployment.
       ipfsGateway: DataTypes.STRING, // URL of the gateway associated with the pinner used for deployment.
-      ipfsHash: DataTypes.STRING // IPFS hash of the deployment.
+      ipfsHash: DataTypes.STRING, // IPFS hash of the deployment.
+      error: DataTypes.STRING // Optional. Only populated when status is 'Failure'.
     },
     {
       underscored: true,

--- a/backend/models/shop_deployment.js
+++ b/backend/models/shop_deployment.js
@@ -1,10 +1,12 @@
+const { ShopDeploymentStatuses } = require('../enums')
+
 module.exports = (sequelize, DataTypes) => {
   const ShopDeployment = sequelize.define(
     'ShopDeployment',
     {
       shopId: DataTypes.INTEGER,
-      // Depreciated.  should be added to shop_deployment_names
-      domain: DataTypes.STRING,
+      status: DataTypes.ENUM(ShopDeploymentStatuses),
+      domain: DataTypes.STRING, // Depreciated.  should be added to shop_deployment_names
       ipfsPinner: DataTypes.STRING, // URL of the IPFS pinner service used for the deployment.
       ipfsGateway: DataTypes.STRING, // URL of the gateway associated with the pinner used for deployment.
       ipfsHash: DataTypes.STRING // IPFS hash of the deployment.

--- a/backend/routes/shops.js
+++ b/backend/routes/shops.js
@@ -1075,46 +1075,6 @@ module.exports = function (router) {
   )
 
   /**
-   * Create a shop deployment record
-   */
-  router.post(
-    '/shops/:shopId/create-deployment',
-    authSellerAndShop,
-    authRole('admin'),
-    async (req, res) => {
-      // Only used for testing
-      if (process.env.NODE_ENV !== 'test') {
-        return res.status(404).json({ success: false })
-      }
-
-      const shopId = req.shop.id
-      const { ipfsHash, ipfsGateway } = req.body
-
-      let deployment = await ShopDeployment.findOne({
-        where: {
-          shopId: shopId,
-          ipfsHash
-        },
-        order: [['createdAt', 'desc']]
-      })
-
-      if (deployment) {
-        return res
-          .status(400)
-          .json({ success: false, message: 'Deployment exists' })
-      }
-
-      deployment = await ShopDeployment.create({
-        shopId: shopId,
-        ipfsGateway,
-        ipfsHash
-      })
-
-      return res.status(200).json({ success: true, deployment })
-    }
-  )
-
-  /**
    * Get names (DNS names, crypto names, etc) for a shop
    */
   router.get(

--- a/backend/routes/shops.js
+++ b/backend/routes/shops.js
@@ -966,6 +966,7 @@ module.exports = function (router) {
       const { hash, domain } = await deployShop(deployOpts)
       return res.json({ success: true, hash, domain, gateway: network.ipfs })
     } catch (e) {
+      log.error(`Shop ${shop.id} deploy failed: ${e}`)
       return res.json({ success: false, reason: e.message })
     }
   })
@@ -1032,7 +1033,7 @@ module.exports = function (router) {
 
         return res.json({ success: true, hash, domain, gateway: network.ipfs })
       } catch (e) {
-        log.error(e)
+        log.error(`Shop ${req.shop.id} initial deploy failed: ${e}`)
         return res.json({ success: false, reason: e.message })
       }
     }

--- a/backend/test/const.js
+++ b/backend/test/const.js
@@ -5,7 +5,8 @@ const BACKEND_PORT = 8357
 module.exports = {
   BACKEND_PORT,
   ROOT_BACKEND_URL: `http://localhost:${BACKEND_PORT}`,
-  IPFS_GATEWAY: `http://localhost:8080`,
+  IPFS_API: 'http://localhost:5002',
+  IPFS_GATEWAY: 'http://localhost:8080',
   TEST_NETWORK_ID: 999,
   TEST_TMP_DIR,
   TEST_DATABASE_URL: `sqlite:${TEST_TMP_DIR}/dshop.db`,

--- a/backend/test/shop.test.js
+++ b/backend/test/shop.test.js
@@ -2,7 +2,15 @@ const chai = require('chai')
 chai.use(require('chai-string'))
 const expect = chai.expect
 
-const { Shop } = require('../models')
+const { deployShop } = require('../utils/deployShop')
+const { ShopDeploymentStatuses } = require('../enums')
+
+const {
+  Shop,
+  ShopDeployment,
+  ShopDeploymentName,
+  Network
+} = require('../models')
 
 const { apiRequest } = require('./utils')
 const {
@@ -14,12 +22,43 @@ const {
   TEST_LISTING_ID_1,
   TEST_HASH_1,
   IPFS_GATEWAY,
+  IPFS_API,
   TEST_UNSTOPPABLE_DOMAIN_1
 } = require('./const')
 
 describe('Shops', () => {
-  let shopId, dataDir
-  before(async () => {})
+  let network, shop, deployment, dataDir
+
+  before(async () => {
+    // Note: the migration inserts a network row for network id 999.
+    network = await Network.findOne({ where: { networkId: 999 } })
+    expect(network).to.be.an('object')
+  })
+
+  /*
+  let network, shop, job, jobId, trans
+
+  before(async () => {
+    network = await getOrCreateTestNetwork()
+
+    // Use account 1 as the merchant's.
+    const sellerWallet = getTestWallet(1)
+    const sellerPk = sellerWallet.privateKey
+
+    // Create the merchant's PGP key.
+    const pgpPrivateKeyPass = 'password123'
+    const key = await generatePgpKey('tester', pgpPrivateKeyPass)
+    const pgpPublicKey = key.publicKeyArmored
+    const pgpPrivateKey = key.privateKeyArmored
+
+    shop = await createTestShop({
+      network,
+      sellerPk,
+      pgpPrivateKeyPass,
+      pgpPublicKey,
+      pgpPrivateKey
+    })
+  })*/
 
   // TODO: Move this to setup/fixture?
   it('create super admin', async () => {
@@ -35,7 +74,6 @@ describe('Shops', () => {
       endpoint: '/auth/registration',
       body
     })
-
     expect(jason.success).to.be.true
   })
 
@@ -83,41 +121,150 @@ describe('Shops', () => {
 
     expect(jason.success).to.be.true
 
-    const shop = await Shop.findOne({ where: { name: shopName } })
+    shop = await Shop.findOne({ where: { name: shopName } })
     expect(shop).to.be.an('object')
     expect(shop.name).to.equal(body.name)
     expect(shop.hostname).to.startsWith(body.dataDir)
     // TODO: check shop.config
-
-    shopId = shop.id
   })
 
-  it('should add a deployment', async () => {
-    // This explicitly only works in testing to avoid actual deployments
-    const jason = await apiRequest({
-      method: 'POST',
-      endpoint: `/shops/${shopId}/create-deployment`,
-      body: {
-        ipfsHash: TEST_HASH_1,
-        ipfsGateway: IPFS_GATEWAY
-      },
-      headers: {
-        Authorization: `Bearer ${dataDir}`
+  it('should deploy a shop', async () => {
+    const testDomain = 'bugfreecode.ai'
+    async function mockDeployFn(args) {
+      return {
+        ipfsHash: 'hash' + Date.now(), // Unique hash.
+        ipfsPinner: IPFS_API,
+        ipfsGateway: IPFS_GATEWAY,
+        domain: testDomain,
+        hostname: `${args.subdomain}.${testDomain}`
       }
+    }
+    const args = {
+      OutputDir: '/tmp',
+      dataDir: '/tmp/dataDir',
+      network,
+      shop,
+      subdomain: 'test',
+      pinner: undefined,
+      deployFn: mockDeployFn
+    }
+    const { hash, domain } = await deployShop(args)
+
+    expect(hash).to.be.an('string')
+    expect(domain).to.be.equal(testDomain)
+
+    // Check a new deployment row was created.
+    deployment = await ShopDeployment.findOne({
+      where: { shopId: shop.id },
+      order: [['id', 'desc']]
     })
-    expect(jason.success).to.be.true
-    expect(jason.deployment.id).to.be.a('number')
-    expect(jason.deployment.shopId).to.be.a('number')
-    expect(jason.deployment.ipfsGateway).to.be.a('string')
-    expect(jason.deployment.ipfsGateway).to.be.equal(IPFS_GATEWAY)
-    expect(jason.deployment.ipfsHash).to.be.a('string')
-    expect(jason.deployment.ipfsHash).to.be.equal(TEST_HASH_1)
+    expect(deployment).to.be.an('object')
+    expect(deployment.shopId).to.equal(shop.id)
+    expect(deployment.status).to.equal(ShopDeploymentStatuses.Success)
+    expect(deployment.domain).to.equal(domain)
+    expect(deployment.ipfsPinner).to.equal(IPFS_API)
+    expect(deployment.ipfsGateway).to.equal(IPFS_GATEWAY)
+    expect(deployment.ipfsHash).to.equal(hash)
+
+    // Check a new deployment_name row was created.
+    const deploymentName = await ShopDeploymentName.findOne({
+      where: { ipfsHash: hash }
+    })
+    expect(deploymentName).to.be.an('object')
+    expect(deploymentName.hostname).to.equal(`${args.subdomain}.${testDomain}`)
+  })
+
+  it('should not deploy a shop if a deploy is already running', async () => {
+    // Update the previous deploy to be pending.
+    await deployment.update({ status: ShopDeploymentStatuses.Pending })
+
+    // An attempt to do a deploy on the same shop should result in an error.
+    const args = {
+      OutputDir: '/tmp',
+      dataDir: '/tmp/dataDir',
+      network,
+      shop,
+      subdomain: 'test',
+      pinner: undefined,
+      deployFn: () => {}
+    }
+    let error
+    try {
+      await deployShop(args)
+    } catch (e) {
+      error = e
+    }
+    expect(error).to.not.be.undefined
+    expect(error.message).to.equal(
+      'Deployment failed. Detected concurrent deployment.'
+    )
+  })
+
+  it('should deploy a shop if an old deploy is pending', async () => {
+    // Update the previous deployment to be pending and old.
+
+    // await deployment.update({ status: ShopDeploymentStatuses.Pending, createdAt: new Date(Date.now() - 30 * 60 * 1000 ) })
+    const anHourAgo = new Date(Date.now() - 60 * 60 * 1000)
+    await deployment.sequelize.query(
+      `UPDATE shop_deployments SET status='Pending', created_at='${anHourAgo}' WHERE id = ${deployment.id};`
+    )
+
+    const testDomain = 'testsareforchampions.dev'
+    async function mockDeployFn(args) {
+      return {
+        ipfsHash: TEST_HASH_1, // Unique hash.
+        ipfsPinner: IPFS_API,
+        ipfsGateway: IPFS_GATEWAY,
+        domain: testDomain,
+        hostname: `${args.subdomain}.${testDomain}`
+      }
+    }
+    const args = {
+      OutputDir: '/tmp',
+      dataDir: '/tmp/dataDir',
+      network,
+      shop,
+      subdomain: 'test',
+      pinner: undefined,
+      deployFn: mockDeployFn
+    }
+    const { hash, domain } = await deployShop(args)
+
+    expect(hash).to.be.an('string')
+    expect(domain).to.be.equal(testDomain)
+
+    // Check the old deployment status was changed to Failed.
+    await deployment.reload()
+    expect(deployment.status).to.equal(ShopDeploymentStatuses.Failed)
+
+    // Check a new deployment row was created.
+    const newDeployment = await ShopDeployment.findOne({
+      where: { shopId: shop.id },
+      order: [['id', 'desc']]
+    })
+    expect(newDeployment.id).to.be.gt(deployment.id)
+    expect(newDeployment).to.be.an('object')
+    expect(newDeployment.shopId).to.equal(shop.id)
+    expect(newDeployment.status).to.equal(ShopDeploymentStatuses.Success)
+    expect(newDeployment.domain).to.equal(domain)
+    expect(newDeployment.ipfsPinner).to.equal(IPFS_API)
+    expect(newDeployment.ipfsGateway).to.equal(IPFS_GATEWAY)
+    expect(newDeployment.ipfsHash).to.equal(hash)
+
+    // Check a new deployment_name row was created.
+    const newDeploymentName = await ShopDeploymentName.findOne({
+      where: { ipfsHash: hash }
+    })
+    expect(newDeploymentName).to.be.an('object')
+    expect(newDeploymentName.hostname).to.equal(
+      `${args.subdomain}.${testDomain}`
+    )
   })
 
   it('should set a name for a deployment', async () => {
     const jason = await apiRequest({
       method: 'POST',
-      endpoint: `/shops/${shopId}/set-names`,
+      endpoint: `/shops/${shop.id}/set-names`,
       body: {
         ipfsHash: TEST_HASH_1,
         hostnames: [TEST_UNSTOPPABLE_DOMAIN_1]
@@ -134,9 +281,9 @@ describe('Shops', () => {
     expect(jason.names[0]).to.be.equal(TEST_UNSTOPPABLE_DOMAIN_1)
   })
 
-  it('should get a names for a shop', async () => {
+  it('should get names for a shop', async () => {
     const jason = await apiRequest({
-      endpoint: `/shops/${shopId}/get-names`,
+      endpoint: `/shops/${shop.id}/get-names`,
       headers: {
         Authorization: `Bearer ${dataDir}`
       }
@@ -144,7 +291,7 @@ describe('Shops', () => {
 
     expect(jason.success).to.be.true
     expect(jason.names).to.be.an('array')
-    expect(jason.names).to.have.lengthOf(1)
+    expect(jason.names).to.have.lengthOf(3)
     expect(jason.names[0]).to.be.equal(TEST_UNSTOPPABLE_DOMAIN_1)
   })
 })

--- a/backend/test/shop.test.js
+++ b/backend/test/shop.test.js
@@ -35,31 +35,6 @@ describe('Shops', () => {
     expect(network).to.be.an('object')
   })
 
-  /*
-  let network, shop, job, jobId, trans
-
-  before(async () => {
-    network = await getOrCreateTestNetwork()
-
-    // Use account 1 as the merchant's.
-    const sellerWallet = getTestWallet(1)
-    const sellerPk = sellerWallet.privateKey
-
-    // Create the merchant's PGP key.
-    const pgpPrivateKeyPass = 'password123'
-    const key = await generatePgpKey('tester', pgpPrivateKeyPass)
-    const pgpPublicKey = key.publicKeyArmored
-    const pgpPrivateKey = key.privateKeyArmored
-
-    shop = await createTestShop({
-      network,
-      sellerPk,
-      pgpPrivateKeyPass,
-      pgpPublicKey,
-      pgpPrivateKey
-    })
-  })*/
-
   // TODO: Move this to setup/fixture?
   it('create super admin', async () => {
     // This explicitly only works in testing to avoid actual deployments
@@ -196,14 +171,13 @@ describe('Shops', () => {
     }
     expect(error).to.not.be.undefined
     expect(error.message).to.equal(
-      'Deployment failed. Detected concurrent deployment.'
+      'The shop is already being published. Try again in a few minutes.'
     )
   })
 
   it('should deploy a shop if an old deploy is pending', async () => {
     // Update the previous deployment to be pending and old.
-
-    // await deployment.update({ status: ShopDeploymentStatuses.Pending, createdAt: new Date(Date.now() - 30 * 60 * 1000 ) })
+    // Note: we use a raw query since Sequelize doesn't allow to update the created_at column.
     const anHourAgo = new Date(Date.now() - 60 * 60 * 1000)
     await deployment.sequelize.query(
       `UPDATE shop_deployments SET status='Pending', created_at='${anHourAgo}' WHERE id = ${deployment.id};`
@@ -233,9 +207,9 @@ describe('Shops', () => {
     expect(hash).to.be.an('string')
     expect(domain).to.be.equal(testDomain)
 
-    // Check the old deployment status was changed to Failed.
+    // Check the old deployment status was changed to a failure.
     await deployment.reload()
-    expect(deployment.status).to.equal(ShopDeploymentStatuses.Failed)
+    expect(deployment.status).to.equal(ShopDeploymentStatuses.Failure)
 
     // Check a new deployment row was created.
     const newDeployment = await ShopDeployment.findOne({

--- a/backend/test/utils.js
+++ b/backend/test/utils.js
@@ -183,6 +183,8 @@ async function getOrCreateTestNetwork() {
       deployDir: 'deployDir'
     })
   }
+  // Note: For unclear reasons, the migration file 20200317190719-addIpfs.js
+  // inserts a row for network 999. Therefore the update case below...
   let network = await Network.findOne({
     where: { networkId: networkObj.networkId }
   })

--- a/backend/utils/deployShop.js
+++ b/backend/utils/deployShop.js
@@ -3,6 +3,7 @@ const ipfsClient = require('ipfs-http-client')
 const fs = require('fs')
 const { execFile } = require('child_process')
 
+const { ShopDeploymentStatuses } = require('../enums')
 const { ShopDeployment, ShopDeploymentName } = require('../models')
 const { autosslQueue } = require('../queues/queues')
 const { getLogger } = require('../utils/logger')
@@ -18,6 +19,9 @@ const LOCAL_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0']
 const PROTOCOL_LABS_GATEWAY = 'https://gateway.ipfs.io'
 const PINATA_API = 'https://api.pinata.cloud'
 const PINATA_GATEWAY = 'https://gateway.pinata.cloud'
+
+// Max age of a deployment before it is considered as failed.
+const MAX_PENDING_DEPLOYMENT_AGE = 5 * 60 * 1000 // 5 min
 
 /**
  * Convert an HTTP URL into a multiaddr
@@ -95,7 +99,8 @@ async function configureShopDNS({
 }
 
 /**
- * Deploys a DShop
+ * Internal logic for deploying a shop.
+ *
  * @param {string} OutputDir: directory to use for preparing the set of files to deploy.
  * @param {string} dataDir: name of the directory for storing the shop's data files.
  * @param {models.Network} network: network configuration DB object.
@@ -106,8 +111,9 @@ async function configureShopDNS({
  *        If for example an IPFS cluster and Pinata are configured, both are used for deployment.
  * @param {string} dnsProvider: DNS provider to use for configuring the domain. 'gcp' or 'cloudflare'
  * @returns {Promise<{domain: string, hash: string}>} Domain configured and IPFS hash of the deployment.
+ * @throws
  */
-async function deployShop({
+async function _deployShop({
   OutputDir,
   dataDir,
   network,
@@ -119,7 +125,7 @@ async function deployShop({
   const networkConfig = getConfig(network.config)
   const zone = networkConfig.domain
 
-  log.info('Preparing data for deploy...')
+  log.info('Shop ${shop.id}: Preparing data for deploy...')
   await new Promise((resolve, reject) => {
     execFile('rm', ['-rf', `${OutputDir}/public`], (error, stdout) => {
       if (error) reject(error)
@@ -154,7 +160,8 @@ async function deployShop({
     const raw = fs.readFileSync(`${OutputDir}/data/config.json`)
     publicShopConfig = JSON.parse(raw.toString())
   } catch (e) {
-    /* Ignore */
+    log.warning(`Shop ${shop.id}: failed parsing ${OutputDir}/data/config.json`)
+    // TODO: Under which circumstances would it be ok for this to not be a hard error?
   }
 
   const networkName =
@@ -182,7 +189,7 @@ async function deployShop({
   const pinataConfigured = networkConfig.pinataKey && networkConfig.pinataSecret
 
   // Build a list of all configured pinners.
-  let pinnerUrl, pinnerGatewayUrl
+  let ipfsPinner, ipfsGateway
   const remotePinners = []
   const ipfsDeployCredentials = {}
   if (ipfsClusterConfigured) {
@@ -199,8 +206,8 @@ async function deployShop({
     }
     remotePinners.push('ipfs-cluster')
     if (pinner === 'ipfs-cluster') {
-      pinnerUrl = maddr
-      pinnerGatewayUrl = network.ipfs
+      ipfsPinner = maddr
+      ipfsGateway = network.ipfs
     }
   }
 
@@ -212,16 +219,16 @@ async function deployShop({
     }
     remotePinners.push('pinata')
     if (pinner === 'pinata') {
-      pinnerUrl = PINATA_API
-      pinnerGatewayUrl = PINATA_GATEWAY
+      ipfsPinner = PINATA_API
+      ipfsGateway = PINATA_GATEWAY
     }
   }
 
   // Deploy the shop to all the configured IPFS pinners.
-  let hash
+  let ipfsHash
   const publicDirPath = `${OutputDir}/public`
   if (remotePinners.length > 0) {
-    hash = await deploy({
+    ipfsHash = await deploy({
       publicDirPath,
       remotePinners,
       siteDomain: dataDir,
@@ -229,19 +236,21 @@ async function deployShop({
       writeLog: log.info,
       writeError: log.error
     })
-    if (!hash) {
+    if (!ipfsHash) {
       throw new Error('IPFS deploy error')
     }
-    log.info(`Deployed shop to ${remotePinners.length} pinners. Hash=${hash}`)
+    log.info(
+      `Deployed shop to ${remotePinners.length} pinners. Hash=${ipfsHash}`
+    )
 
     // Prime various IPFS gateways.
     log.info('Priming gateways...')
-    await prime(`${PROTOCOL_LABS_GATEWAY}/ipfs/${hash}`, publicDirPath)
+    await prime(`${PROTOCOL_LABS_GATEWAY}/ipfs/${ipfsHash}`, publicDirPath)
     if (networkConfig.pinataKey) {
-      await prime(`${PINATA_GATEWAY}/ipfs/${hash}`, publicDirPath)
+      await prime(`${PINATA_GATEWAY}/ipfs/${ipfsHash}`, publicDirPath)
     }
     if (network.ipfs) {
-      await prime(`${network.ipfs}/ipfs/${hash}`, publicDirPath)
+      await prime(`${network.ipfs}/ipfs/${ipfsHash}`, publicDirPath)
     }
   } else if (network.ipfsApi.indexOf('localhost') > 0) {
     // Local dev deployment.
@@ -249,22 +258,27 @@ async function deployShop({
     const file = await ipfs.add(
       ipfsClient.globSource(publicDirPath, { recursive: true })
     )
-    hash = String(file.cid)
-    pinnerUrl = network.ipfsApi
-    pinnerGatewayUrl = network.ipfs
-    log.info(`Deployed shop on local IPFS. Hash=${hash}`)
+    ipfsHash = String(file.cid)
+    ipfsPinner = network.ipfsApi
+    ipfsGateway = network.ipfs
+    log.info(`Deployed shop on local IPFS. Hash=${ipfsHash}`)
   } else {
-    log.warn(
-      'Shop not deployed to IPFS: Pinner service not configured and not a dev environment.'
-    )
+    throw new Error('Shop not deployed to IPFS: Pinner service not configured')
   }
 
   // Configure DNS.
-  let domain
+  let domain, hostname
   if (subdomain) {
     log.info('Configuring DNS...')
     domain = dnsProvider ? `https://${subdomain}.${zone}` : null
-    await configureShopDNS({ network, subdomain, zone, hash, dnsProvider })
+    hostname = `${subdomain}.${zone}`
+    await configureShopDNS({
+      network,
+      subdomain,
+      zone,
+      hash: ipfsHash,
+      dnsProvider
+    })
     if (domain && network.ipfs) {
       // Intentionally not awaiting on this so we can return to the user faster
       await autosslQueue.add({
@@ -274,41 +288,108 @@ async function deployShop({
     }
   }
 
-  if (hash) {
-    // Record the deployment in the DB.
-    try {
-      const deployment = await ShopDeployment.create({
-        shopId: shop.id,
-        domain,
-        ipfsPinner: pinnerUrl,
-        ipfsGateway: pinnerGatewayUrl,
-        ipfsHash: hash
-      })
+  return { ipfsHash, ipfsPinner, ipfsGateway, domain, hostname }
+}
 
-      if (subdomain) {
-        const hostname = `${subdomain}.${zone}`
-        // There could be an existing entry by the same hash/hostname.
-        // For example if a store gets redeployed without changes, its hash remains identical.
-        const deploymentName = await ShopDeploymentName.findOne({
-          where: { ipfsHash: hash, hostname }
-        })
-        if (!deploymentName) {
-          await ShopDeploymentName.create({
-            ipfsHash: hash,
-            hostname
-          })
-        }
-      }
+/**
+ * Deploys a DShop
+ * @param {string} OutputDir: directory to use for preparing the set of files to deploy.
+ * @param {string} dataDir: name of the directory for storing the shop's data files.
+ * @param {models.Network} network: network configuration DB object.
+ * @param {string} subdomain
+ * @param {models.Shop} shop: shop DB object.
+ * @param {string} pinner: Pinner service to use for deploying the shop's data. 'ipfs-cluster' or 'pinata'.
+ *        NOTE: Currently this argument is ignored and the data is deployed to all the pinners configured.
+ *        If for example an IPFS cluster and Pinata are configured, both are used for deployment.
+ * @param {string} dnsProvider: DNS provider to use for configuring the domain. 'gcp' or 'cloudflare'
+ * @param {models.ShopDeployment}: deployment DB row.
+ * @returns {Promise<{domain: string, hash: string}>} Domain configured and IPFS hash of the deployment.
+ * @throws
+ */
+async function deployShop(args) {
+  const { shop } = args
 
-      log.info(
-        `Recorded shop deployment in the DB. id=${deployment.id} domain=${domain} hash=${hash}`
+  // Check if there is any pending deployment to prevent concurrent deployments.
+  const pendingDeployment = await ShopDeployment.findOne({
+    shopId: shop.id,
+    status: ShopDeploymentStatuses.Pending
+  })
+  if (pendingDeployment) {
+    // There is a pending deployment. There is a slight chance a deployment
+    // may have been interrupted by server crash or a maintenance, causing it
+    // to never finish.
+    const age = pendingDeployment.createdAt - Date.now()
+    if (age > MAX_PENDING_DEPLOYMENT_AGE) {
+      // Mark the deployment as failed.
+      log.warn(
+        `Found stale pending deployment ${pendingDeployment.id}. Updating it as failed.`
       )
-    } catch (e) {
-      log.error('Error recording the shop deployment in the DB', e)
+      await pendingDeployment.update({
+        status: ShopDeploymentStatuses.Failed,
+        error: `Stale pending deployment`
+      })
+    } else {
+      log.error(
+        `Shop ${shop.id}: concurrent deployment running. Can not start a new deploy.`
+      )
+      throw new Error(`Deployment failed. Detected concurrent deployment.`)
     }
   }
 
-  return { hash, domain }
+  // Create a deployment row in the DB.
+  const deployment = await ShopDeployment.create({
+    shopId: shop.id,
+    status: ShopDeploymentStatuses.Pending
+  })
+
+  let result
+  try {
+    // Deploy the shop.
+    result = await _deployShop(args)
+  } catch (e) {
+    log.error(`Shop ${shop.id} deployment failure: ${e}`)
+    // Record the deployment failure in the DB.
+    await deployment.update({
+      status: ShopDeploymentStatuses.Failed,
+      error: e.toString()
+    })
+    // Rethrow to notify the caller of the failure.
+    throw e
+  }
+
+  const { ipfsHash, ipfsPinner, ipfsGateway, domain, hostname } = result
+
+  // Record the deployment name in the DB.
+  if (hostname) {
+    // There could be an existing entry by the same hash/hostname.
+    // For example if a store gets redeployed without changes, its hash remains identical.
+    const deploymentName = await ShopDeploymentName.findOne({
+      where: { ipfsHash, hostname }
+    })
+    if (!deploymentName) {
+      await ShopDeploymentName.create({
+        ipfsHash,
+        hostname
+      })
+    }
+  }
+
+  // Update the deployment in the DB.
+  await deployment.update({
+    status: ShopDeploymentStatuses.Success,
+    domain,
+    ipfsPinner,
+    ipfsGateway,
+    ipfsHash
+  })
+  log.info(
+    `Deployed shop ${shop.id}: deployment id=${deployment.id} domain=${domain} hash=${ipfsHash}`
+  )
+
+  return { hash: ipfsHash, domain }
 }
 
-module.exports = { configureShopDNS, deployShop }
+module.exports = {
+  configureShopDNS,
+  deployShop
+}


### PR DESCRIPTION
Fix for #300 

- Added a new column status to shop_deployment and populate it in the deploy logic. It can have 3 values: Pending, Success, Failure
- Updated the logic so that before starting a new deployment, it checks there is no Pending deployment
- Added unit tests
