### PR TITLE
Restrict characters that can be used in the shop name

### DIFF
--- a/backend/routes/shops.js
+++ b/backend/routes/shops.js
@@ -401,11 +401,11 @@ module.exports = function (router) {
       log.error(`Error creating shop: ${shopResponse.error}`)
       return res
         .status(400)
-        .json({ success: false, message: 'Invalid shop data' })
+        .json({ success: false, message: shopResponse.error })
     }
 
     const shopId = shopResponse.shop.id
-    log.info(`Created shop ${shopId}`)
+    log.info(`Created shop ${shopId} with name ${shopResponse.name}`)
 
     const role = 'admin'
     await SellerShop.create({ sellerId: req.session.sellerId, shopId, role })

--- a/backend/utils/shop.js
+++ b/backend/utils/shop.js
@@ -1,5 +1,17 @@
 const { Shop } = require('../models')
 
+/**
+ * Create a new shop in the DB.
+ *
+ * @param {number} networkId: 1=Mainnet, 4=Rinkeby, 999=localhost, etc...
+ * @param {string} name: shop name
+ * @param {string} listingId: listing ID associated with the shop
+ * @param {string} authToken: token
+ * @param {string} config: Shop's encrypted configuration
+ * @param {number} sellerId: If of the row in the SellerShop table for the shop's owner
+ * @param {string} hostname: hostname of the shop URL
+ * @returns {Promise<{shop: models.Shop}|{error: string, status: number}>}
+ */
 async function createShop({
   networkId,
   name,
@@ -12,10 +24,30 @@ async function createShop({
   if (!name) {
     return { status: 400, error: 'Provide a shop name' }
   }
+  // Remove any leading/trailing space.
+  name = name.trim()
+
+  // Store name must only contain alpha-numeric characters and space.
+  // TODO: Add support for UTF_8 characters. This requires changes throughout the stack
+  //       and in particular encoding/decoding shop name in URLs.
+  if (!name.match(/^[0-9a-z ]+$/)) {
+    return {
+      status: 400,
+      error:
+        'Shop name contains non alphanumeric character. Please only use [a-zA-z0-9 ] characters.'
+    }
+  }
   if (listingId && !String(listingId).match(/^[0-9]+-[0-9]+-[0-9]+$/)) {
     return {
       status: 400,
       error: 'Listing ID must be of form xxx-xxx-xxx eg 1-001-123'
+    }
+  }
+  if (listingId && !listingId.startsWith(networkId)) {
+    return {
+      status: 400,
+      error:
+        'Listing ID ${listingId} is not on expected Network ID ${networkId}'
     }
   }
   if (!authToken) {


### PR DESCRIPTION
Only allow [a-zA-Z0-9 ]
Other characters cause havoc with our URLs since we don't encode the shop name.