### PR TITLE
Store payment_code in the orders tables

### DIFF
--- a/backend/db/migrations/20200731205137-addPaymentCodeToOrder.js
+++ b/backend/db/migrations/20200731205137-addPaymentCodeToOrder.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async () => {
+      await queryInterface.addColumn('orders', 'payment_code', { type: Sequelize.STRING })
+    })
+  },
+  down: (queryInterface) => {
+    return queryInterface.sequelize.transaction(async () => {
+      await queryInterface.removeColumn('orders', 'payment_code')
+    })
+  }
+}

--- a/backend/models/order.js
+++ b/backend/models/order.js
@@ -53,7 +53,9 @@ module.exports = (sequelize, DataTypes) => {
       // Amount of OGN commission paid to the referrer.
       commissionPaid: DataTypes.INTEGER,
       // Date at which the offer was recorded on-chain.
-      createdAt: DataTypes.DATE
+      createdAt: DataTypes.DATE,
+      // Optional. Links an external payment (ex: credit card) to an order. See external_payments.payment_code
+      paymentCode: DataTypes.STRING
     },
     {
       underscored: true,

--- a/backend/test/order.test.js
+++ b/backend/test/order.test.js
@@ -97,7 +97,8 @@ describe('Orders', () => {
         currency: 'OGN'
       },
       finalizes: 1209600,
-      encryptedData: hash
+      encryptedData: hash,
+      paymentCode: 'code123'
     }
     offerIpfsHash = await post(network.ipfsApi, offer, true)
   })
@@ -126,7 +127,8 @@ describe('Orders', () => {
       topics: [offerCreatedSignature],
       transactionHash: '0x12345',
       blockNumber: 1,
-      mockGetEventObj: () => event
+      mockGetEventObj: () => event,
+      mockUpsert: () => event
     })
 
     expect(order).to.be.undefined
@@ -191,6 +193,7 @@ describe('Orders', () => {
     expect(order.ipfsHash).to.equal(offerIpfsHash)
     expect(order.createdBlock).to.equal(1)
     expect(order.updatedBlock).to.equal(1)
+    expect(order.paymentCode).to.equal('code123')
     expect(order.data).to.eql({
       ...data,
       ...{ offerId: fullOfferId, tx: event.transactionHash }

--- a/backend/utils/handleLog.js
+++ b/backend/utils/handleLog.js
@@ -272,6 +272,10 @@ async function _processEventForNewOrder({
     throw new Error('No encrypted data found')
   }
 
+  // Extract the optional paymentCode data from the offer.
+  // It is populated for example in case of a Credit Card payment.
+  const paymentCode = offer.paymentCode
+
   // Load the encrypted data from IPFS and decrypt it.
   log.info(`Fetching encrypted offer data with hash ${encryptedHash}`)
   const encryptedDataJson = await getText(
@@ -304,7 +308,8 @@ async function _processEventForNewOrder({
     createdAt: new Date(event.timestamp * 1000),
     createdBlock: event.blockNumber,
     ipfsHash: event.ipfsHash,
-    encryptedIpfsHash: encryptedHash
+    encryptedIpfsHash: encryptedHash,
+    paymentCode
   }
   if (data.referrer) {
     orderObj.referrer = util.toChecksumAddress(data.referrer)


### PR DESCRIPTION
When troubleshooting payment/order related issues for orders placed with a credit card, it is nice to be able to link the following tables using the payment_code:
 - external_payments
 - transactions
 - orders

This PR adds a new column payment_code to the orders table and populates it using the offer's data (we already store paymentCode in the offer's JSON data stored on IPFS).