### PR TITLE
[IPFS get] Do not cache exceptions

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "@google-cloud/bigquery": "^5.0.0",
     "@google-cloud/dns": "^2.0.1",
     "@origin/utils": "^0.1.0",
+    "@origin/ipfs": "^0.1.0",
     "aws-sdk": "^2.680.0",
     "bcrypt": "^5.0.0",
     "body-parser": "^1.19.0",

--- a/backend/test/ipfs.utils.test.js
+++ b/backend/test/ipfs.utils.test.js
@@ -1,0 +1,65 @@
+const chai = require('chai')
+const expect = chai.expect
+
+const { getOrCreateTestNetwork } = require('./utils')
+const { getText, get, post, getIpfsHashFromBytes32 } = require('../utils/_ipfs')
+
+describe('IPFS Utils', () => {
+  let network, data1, data1Hash, data2, data2Hash
+
+  before(async () => {
+    network = await getOrCreateTestNetwork()
+    data1 = { name: 'data1' }
+    data2 = { name: 'data2' }
+  })
+
+  it('should post', async () => {
+    data1Hash = await post(network.ipfsApi, data1, true)
+    const data2HashBytes = await post(network.ipfsApi, data2, false)
+    data2Hash = getIpfsHashFromBytes32(data2HashBytes)
+
+    expect(data1Hash).to.be.a('string')
+    expect(data2Hash).to.be.a('string')
+    expect(data2HashBytes).to.startsWith('0x')
+  })
+
+  it('should getText', async () => {
+    const data1Text = await getText(network.ipfs, data1Hash, 1000)
+
+    expect(data1Text).to.be.equal(JSON.stringify(data1))
+  })
+
+  it('should get', async () => {
+    const data2Json = await get(network.ipfs, data2Hash, 1000)
+
+    expect(data2Json).to.be.a('object')
+    expect(data2Json.name).to.be.equal('data2')
+  })
+
+  // Know issue: this test fails if run multiples times.
+  // As a workaround, clar the IPTS service data before running it.
+  // TODO(franck): dynamically generate random data and figure the
+  //  associated hash in order to make this test idempotent.
+  it('should throw a timeout error and succeed on 2nd try', async () => {
+    const data3 = { name: 'data3' }
+    const expectedData3Hash = 'Qmd78po6SFVtys6yP42M2crED7UjRKKydt5D1tkxnVQZg8'
+
+    // Request a non-existent yet piece of content - we expect a timeout.
+    let failure = false
+    try {
+      await get(network.ipfs, expectedData3Hash, 1000)
+    } catch (e) {
+      failure = true
+    }
+    expect(failure).to.be.true
+
+    // Upload the content
+    const data3Hash = await post(network.ipfsApi, data3, true)
+    expect(data3Hash).to.be.equal(expectedData3Hash)
+
+    // Request the content again. This time it should work.
+    const data3Json = await get(network.ipfs, data3Hash, 1000)
+    expect(data3Json).to.be.a('object')
+    expect(data3Json.name).to.be.equal('data3')
+  })
+})

--- a/backend/test/ipfs.utils.test.js
+++ b/backend/test/ipfs.utils.test.js
@@ -4,6 +4,8 @@ const expect = chai.expect
 const { getOrCreateTestNetwork } = require('./utils')
 const { getText, get, post, getIpfsHashFromBytes32 } = require('../utils/_ipfs')
 
+const IPFS_TEST_TIMEOUT = 500 // 500msec
+
 describe('IPFS Utils', () => {
   let network, data1, data1Hash, data2, data2Hash
 
@@ -24,13 +26,13 @@ describe('IPFS Utils', () => {
   })
 
   it('should getText', async () => {
-    const data1Text = await getText(network.ipfs, data1Hash, 1000)
+    const data1Text = await getText(network.ipfs, data1Hash, IPFS_TEST_TIMEOUT)
 
     expect(data1Text).to.be.equal(JSON.stringify(data1))
   })
 
   it('should get', async () => {
-    const data2Json = await get(network.ipfs, data2Hash, 1000)
+    const data2Json = await get(network.ipfs, data2Hash, IPFS_TEST_TIMEOUT)
 
     expect(data2Json).to.be.a('object')
     expect(data2Json.name).to.be.equal('data2')
@@ -47,7 +49,7 @@ describe('IPFS Utils', () => {
     // Request a non-existent yet piece of content - we expect a timeout.
     let failure = false
     try {
-      await get(network.ipfs, expectedData3Hash, 1000)
+      await get(network.ipfs, expectedData3Hash, IPFS_TEST_TIMEOUT)
     } catch (e) {
       failure = true
     }
@@ -58,7 +60,7 @@ describe('IPFS Utils', () => {
     expect(data3Hash).to.be.equal(expectedData3Hash)
 
     // Request the content again. This time it should work.
-    const data3Json = await get(network.ipfs, data3Hash, 1000)
+    const data3Json = await get(network.ipfs, data3Hash, IPFS_TEST_TIMEOUT)
     expect(data3Json).to.be.a('object')
     expect(data3Json.name).to.be.equal('data3')
   })

--- a/backend/test/ipfs.utils.test.js
+++ b/backend/test/ipfs.utils.test.js
@@ -38,8 +38,8 @@ describe('IPFS Utils', () => {
     expect(data2Json.name).to.be.equal('data2')
   })
 
-  // Know issue: this test fails if run multiples times.
-  // As a workaround, clar the IPTS service data before running it.
+  // Known issue: this test fails if run multiples times.
+  // As a workaround, clear the IPTS service data before running it.
   // TODO(franck): dynamically generate random data and figure the
   //  associated hash in order to make this test idempotent.
   it('should throw a timeout error and succeed on 2nd try', async () => {

--- a/backend/utils/_ipfs.js
+++ b/backend/utils/_ipfs.js
@@ -1,15 +1,18 @@
-const bs58 = require('bs58')
-const FormData = require('form-data')
-const fetch = require('node-fetch')
-const memoize = require('lodash/memoize')
+const {
+  get,
+  getText,
+  post,
+  postBinary,
+  getBytes32FromIpfsHash,
+  getIpfsHashFromBytes32,
+  gatewayUrl
+} = require('@origin/ipfs')
+const { memoizePromise } = require('@origin/utils/memoize')
 
 require('dotenv').config()
+
 const config = require('../config')
-const { getLogger } = require('../utils/logger')
-
 const { DATA_URL, IPFS_GATEWAY } = require('./const')
-
-const log = getLogger('utils.handleLog')
 
 /**
  * Resolve an IPFS gateway from whatever's available.  Either a provided config
@@ -32,179 +35,8 @@ async function resolveIPFSGateway(dataURL, networkId) {
   }
   return IPFS_GATEWAY
 }
-const getIPFSGateway = memoize(resolveIPFSGateway)
 
-function getBytes32FromIpfsHash(hash) {
-  return `0x${bs58.decode(hash).slice(2).toString('hex')}`
-}
-
-/**
- * Returns base58 encoded ipfs hash from bytes32 hex string.
- * Ex.: "0x017dfd85d4f6cb4dcd715a88101f7b1f06cd1e009b2327a0809d01eb9c91f231"
- *      ->"QmNSUYVKDSvPUnRLKmuxk9diJ6yS96r1TrAXzjTiBcCLAL"
- *
- * @param {string} bytes32Hex
- * @returns {string}
- */
-function getIpfsHashFromBytes32(bytes32Hex) {
-  // Add our default ipfs values for first 2 bytes:
-  // function:0x12=sha2, size:0x20=256 bits
-  // and cut off leading "0x"
-  const hashHex = '1220' + bytes32Hex.slice(2)
-  const hashBytes = Buffer.from(hashHex, 'hex')
-  const hashStr = bs58.encode(hashBytes)
-  return hashStr
-}
-
-/**
- * Takes an IPFS hash url (for example: ipfs://QmUwefhweuf...12322a) and
- * returns a url to that resource on the gateway.
- * Ensures that the IPFS hash does not contain anything evil and is the correct length.
- *
- * @param {string} gateway
- * @param {string} ipfsUrl
- * @returns {string}
- */
-function gatewayUrl(gateway, ipfsUrl) {
-  if (!ipfsUrl) {
-    return
-  }
-  const match = ipfsUrl.match(/^ipfs:\/\/([A-Za-z0-9]{46})$/)
-  if (match) {
-    return `${gateway}/ipfs/${match[1]}`
-  }
-}
-
-/**
- * Stores a JSON object as a text in IPFS.
- *
- * @param {string} gateway: URL of the IPFS gateway to use for the upload.
- * @param {object} json: JSON object to upload.
- * @param {boolean} rawHash: whether to return the hash in its raw format or as bytes32
- * @returns {Promise<string>}
- */
-async function post(gateway, json, rawHash) {
-  const formData = new FormData()
-  let file
-  if (typeof Blob === 'undefined') {
-    file = Buffer.from(JSON.stringify(json))
-  } else {
-    file = new Blob([JSON.stringify(json)])
-  }
-  formData.append('file', file)
-
-  const rawRes = await fetch(`${gateway}/api/v0/add`, {
-    method: 'POST',
-    body: formData
-  })
-  const res = await rawRes.json()
-  if (rawHash) {
-    return res.Hash
-  } else {
-    return getBytes32FromIpfsHash(res.Hash)
-  }
-}
-
-/**
- * Posts binary data to IPFS and returns the base 58 encoded hash.
- *
- * @param {string} gateway: URL of the IPFS gateway to use.
- * @param {Buffer} buffer: binary data to upload.
- * @returns {Promise<{string}>}
- * @throws
- */
-async function postBinary(gateway, buffer) {
-  const formData = new FormData()
-  formData.append('file', buffer)
-  const rawRes = await fetch(`${gateway}/api/v0/add`, {
-    method: 'POST',
-    body: formData
-  })
-  const res = await rawRes.json()
-  return res.Hash
-}
-
-/**
- * Fetches content from IPFS and returns it as a string.
- *
- * @param {string} gateway: URL of the IPFS gateway to use.
- * @param {string} hashAsBytes: IPFS hash.
- * @param {number} timeoutMS: Timeout in msec.
- * @returns {Promise<string>}
- * @throws
- */
-async function getTextFn(gateway, hashAsBytes, timeoutMS) {
-  const hash =
-    hashAsBytes.indexOf('0x') === 0
-      ? getIpfsHashFromBytes32(hashAsBytes)
-      : hashAsBytes
-  const response = await new Promise((resolve, reject) => {
-    let didTimeOut = false
-    const timeout = setTimeout(() => {
-      didTimeOut = true
-      reject(new Error('IPFS gateway timeout'))
-    }, timeoutMS)
-    fetch(`${gateway}/ipfs/${hash}`)
-      .then((response) => {
-        clearTimeout(timeout)
-        if (!didTimeOut) {
-          resolve(response)
-        }
-      })
-      .catch((error) => {
-        clearTimeout(timeout)
-        if (!didTimeOut) {
-          reject(error)
-        }
-      })
-    if (didTimeOut) log.warn(`Timeout when fetching ${hash}`)
-  })
-  if (!response) {
-    return '{}'
-  }
-  return await response.text()
-}
-
-/**
- * Utility method to use as a wrapper for for memoize when used with async function.
- * Prevents memoize from caching the result in case the function threw an exception.
- *
- * @param {function} f: the function to call and cache result for
- * @param {function} resolver: function to get the cache key to use
- * @returns {function}
- */
-function memoizePromise(f, resolver = (k) => k) {
-  const memorizedFunction = memoize(async function (...args) {
-    try {
-      return await f(...args)
-    } catch (e) {
-      // Function threw an exception. Do not cache the result.
-      memorizedFunction.cache.delete(resolver(...args))
-      throw e
-    }
-  }, resolver)
-  return memorizedFunction
-}
-
-// Memoized version of getTextFn
-const getText = memoizePromise(getTextFn, (...args) => args[1])
-
-/**
- * Fetches content from IPFS and returns it as a JSON object.
- *
- * @param {string} gateway: URL of the IPFS gateway to use.
- * @param {string} hashAsBytes: IPFS hash.
- * @param {number} timeoutMS: Timeout in msec.
- * @returns {Promise<object>}
- * @throws
- */
-async function get(gateway, hashAsBytes, timeoutMS = 10000) {
-  if (!hashAsBytes) return null
-
-  const text = await getText(gateway, hashAsBytes, timeoutMS)
-
-  return JSON.parse(text)
-}
+const getIPFSGateway = memoizePromise(resolveIPFSGateway)
 
 module.exports = {
   get,

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@origin/utils": "^0.1.0",
     "bs58": "4.0.1",
     "cross-fetch": "3.0.5",
     "eslint": "7.6.0",

--- a/packages/ipfs/src/index.js
+++ b/packages/ipfs/src/index.js
@@ -1,21 +1,31 @@
-// export function getBytes32FromIpfsHash(hash) {
-//   return hash;
-// }
-// export function getIpfsHashFromBytes32(bytes32Hex) {
-//   return bytes32Hex;
-// }
 const bs58 = require('bs58')
 const FormData = require('form-data')
 const fetch = require('cross-fetch')
-const memoize = require('lodash/memoize')
 
+const { memoizePromise } = require('@origin/utils/memoize')
+
+// NOTE: tests for methods are under src/backend/tests/ipfs.utils.test.js
+
+/**
+ * Takes an IPFS base58 encoded hash and returns it bytes32 encoded.
+ * Ex.: "QmNSUYVKDSvPUnRLKmuxk9diJ6yS96r1TrAXzjTiBcCLAL"
+ *      -> "0x017dfd85d4f6cb4dcd715a88101f7b1f06cd1e009b2327a0809d01eb9c91f231"
+ *
+ * @param {string} hash: base58 encoded hash
+ * @returns {string}
+ */
 function getBytes32FromIpfsHash(hash) {
   return `0x${bs58.decode(hash).slice(2).toString('hex')}`
 }
 
-// Return base58 encoded ipfs hash from bytes32 hex string,
-// E.g. "0x017dfd85d4f6cb4dcd715a88101f7b1f06cd1e009b2327a0809d01eb9c91f231"
-// --> "QmNSUYVKDSvPUnRLKmuxk9diJ6yS96r1TrAXzjTiBcCLAL"
+/**
+ * Returns base58 encoded ipfs hash from bytes32 hex string.
+ * Ex.: "0x017dfd85d4f6cb4dcd715a88101f7b1f06cd1e009b2327a0809d01eb9c91f231"
+ *      ->"QmNSUYVKDSvPUnRLKmuxk9diJ6yS96r1TrAXzjTiBcCLAL"
+ *
+ * @param {string} bytes32Hex
+ * @returns {string}
+ */
 function getIpfsHashFromBytes32(bytes32Hex) {
   // Add our default ipfs values for first 2 bytes:
   // function:0x12=sha2, size:0x20=256 bits
@@ -30,6 +40,7 @@ function getIpfsHashFromBytes32(bytes32Hex) {
  * Takes an IPFS hash url (for example: ipfs://QmUwefhweuf...12322a) and
  * returns a url to that resource on the gateway.
  * Ensures that the IPFS hash does not contain anything evil and is the correct length.
+ *
  * @param {string} gateway
  * @param {string} ipfsUrl
  * @returns {string}
@@ -44,15 +55,14 @@ function gatewayUrl(gateway, ipfsUrl) {
   }
 }
 
-// async function postFile(gateway, file) {
-//   const body = new FormData()
-//   body.append('file', file)
-//
-//   const rawRes = await fetch(`${gateway}/api/v0/add`, { method: 'POST', body })
-//   const res = await rawRes.json()
-//   return res.Hash
-// }
-
+/**
+ * Stores a JSON object as string-ified text in IPFS.
+ *
+ * @param {string} gateway: URL of the IPFS gateway to use for the upload.
+ * @param {object} json: JSON object to upload.
+ * @param {boolean} rawHash: whether to return the hash in its raw format or as bytes32
+ * @returns {Promise<string>}
+ */
 async function post(gateway, json, rawHash) {
   const formData = new FormData()
   let file
@@ -76,12 +86,12 @@ async function post(gateway, json, rawHash) {
 }
 
 /**
- * Posts binary data to IPFS and return the base 58 encoded hash.
- * Throws in case of an error.
+ * Posts binary data to IPFS and returns the base 58 encoded hash.
  *
  * @param {string} gateway: URL of the IPFS gateway to use.
  * @param {Buffer} buffer: binary data to upload.
  * @returns {Promise<{string}>}
+ * @throws
  */
 async function postBinary(gateway, buffer) {
   const formData = new FormData()
@@ -94,41 +104,15 @@ async function postBinary(gateway, buffer) {
   return res.Hash
 }
 
-// async function postEnc(gateway, json, pubKeys) {
-//   const formData = new FormData()
-//
-//   const publicKeys = pubKeys.reduce(
-//     (acc, val) => acc.concat(openpgp.key.readArmored(val).keys),
-//     []
-//   )
-//
-//   const encrypted = await openpgp.encrypt({
-//     data: JSON.stringify(json),
-//     publicKeys
-//   })
-//
-//   formData.append('file', new Blob([encrypted.data]))
-//
-//   const rawRes = await fetch(`${gateway}/api/v0/add`, {
-//     method: 'POST',
-//     body: formData
-//   })
-//   const res = await rawRes.json()
-//
-//   return getBytes32FromIpfsHash(res.Hash)
-// }
-
-// async function decode(text, key, pass) {
-//   const privKeyObj = openpgp.key.readArmored(key).keys[0]
-//   await privKeyObj.decrypt(pass)
-//
-//   const decrypted = await openpgp.decrypt({
-//     message: openpgp.message.readArmored(text),
-//     privateKeys: [privKeyObj]
-//   })
-//   return decrypted.data
-// }
-
+/**
+ * Fetches content from IPFS and returns it as a string.
+ *
+ * @param {string} gateway: URL of the IPFS gateway to use.
+ * @param {string} hashAsBytes: IPFS hash.
+ * @param {number} timeoutMS: Timeout in msec.
+ * @returns {Promise<string>}
+ * @throws
+ */
 async function getTextFn(gateway, hashAsBytes, timeoutMS) {
   const hash =
     hashAsBytes.indexOf('0x') === 0
@@ -138,7 +122,7 @@ async function getTextFn(gateway, hashAsBytes, timeoutMS) {
     let didTimeOut = false
     const timeout = setTimeout(() => {
       didTimeOut = true
-      reject('IPFS gateway timeout')
+      reject(new Error('IPFS gateway timeout'))
     }, timeoutMS)
     fetch(`${gateway}/ipfs/${hash}`)
       .then((response) => {
@@ -161,20 +145,22 @@ async function getTextFn(gateway, hashAsBytes, timeoutMS) {
   return await response.text()
 }
 
-const getText = memoize(getTextFn, (...args) => args[1])
+// Memoized version of getTextFn
+const getText = memoizePromise(getTextFn, (...args) => args[1])
 
+/**
+ * Fetches content from IPFS and returns it as a JSON object.
+ *
+ * @param {string} gateway: URL of the IPFS gateway to use.
+ * @param {string} hashAsBytes: IPFS hash.
+ * @param {number} timeoutMS: Timeout in msec.
+ * @returns {Promise<object>}
+ * @throws
+ */
 async function get(gateway, hashAsBytes, timeoutMS = 10000) {
-  // }, party) {
   if (!hashAsBytes) return null
 
   const text = await getText(gateway, hashAsBytes, timeoutMS)
-  // if (text.indexOf('-----BEGIN PGP MESSAGE-----') === 0 && party) {
-  //   try {
-  //     text = await decode(text, party.privateKey, party.pgpPass)
-  //   } catch (e) {
-  //     return { encrypted: true, decryptError: e }
-  //   }
-  // }
 
   return JSON.parse(text)
 }

--- a/packages/ipfs/src/index.js
+++ b/packages/ipfs/src/index.js
@@ -4,7 +4,7 @@ const fetch = require('cross-fetch')
 
 const { memoizePromise } = require('@origin/utils/memoize')
 
-// NOTE: tests for methods are under src/backend/tests/ipfs.utils.test.js
+// NOTE: tests for these methods are under src/backend/tests/ipfs.utils.test.js
 
 /**
  * Takes an IPFS base58 encoded hash and returns it bytes32 encoded.
@@ -19,9 +19,9 @@ function getBytes32FromIpfsHash(hash) {
 }
 
 /**
- * Returns base58 encoded ipfs hash from bytes32 hex string.
+ * Returns base58 encoded IPFS hash from bytes32 hex string.
  * Ex.: "0x017dfd85d4f6cb4dcd715a88101f7b1f06cd1e009b2327a0809d01eb9c91f231"
- *      ->"QmNSUYVKDSvPUnRLKmuxk9diJ6yS96r1TrAXzjTiBcCLAL"
+ *      -> "QmNSUYVKDSvPUnRLKmuxk9diJ6yS96r1TrAXzjTiBcCLAL"
  *
  * @param {string} bytes32Hex
  * @returns {string}

--- a/packages/utils/memoize.js
+++ b/packages/utils/memoize.js
@@ -1,0 +1,26 @@
+const memoize = require('lodash/memoize')
+
+/**
+ * Utility method to use as a wrapper for memoize when call on an async function.
+ * Prevents memoize from caching the result in case the function throws an exception.
+ *
+ * @param {function} f: the function to call and cache result for
+ * @param {function} resolver: function to get the cache key to use
+ * @returns {function}
+ */
+function memoizePromise(f, resolver = (k) => k) {
+  const memorizedFunction = memoize(async function (...args) {
+    try {
+      return await f(...args)
+    } catch (e) {
+      // Function threw an exception. Do not cache the result.
+      memorizedFunction.cache.delete(resolver(...args))
+      throw e
+    }
+  }, resolver)
+  return memorizedFunction
+}
+
+module.exports = {
+  memoizePromise
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "lodash": "^4.17.19",
-    "logplease": "^1.2.15"
+    "logplease": "^1.2.15",
+    "@origin/utils": "^0.1.0"
   },
   "devDependencies": {
     "eslint": "7.6.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.19",
-    "logplease": "^1.2.15",
-    "@origin/utils": "^0.1.0"
+    "logplease": "^1.2.15"
   },
   "devDependencies": {
     "eslint": "7.6.0",


### PR DESCRIPTION
The back-end processing queue had a few failures caused by IPFS timeouts. All the retries failed with logs that look like this:
```
2020-08-02T04:49:47.198016519Z [INFO]  dshop.utils.handleLog: Event OfferCreated for listing Id 1-001-233
2020-08-02T04:49:47.201167573Z [DEBUG] dshop.utils.events: Upsert event...
2020-08-02T04:49:47.207408834Z [DEBUG] dshop.utils.events: Event exists
2020-08-02T04:49:47.210113302Z [INFO]  dshop.utils.handleLog: OfferCreated - 592 by 0xDF73aF150b8E446a6D39FDdc2CFA7Bf067B88936
2020-08-02T04:49:47.210283391Z [INFO]  dshop.utils.handleLog: IPFS Hash: QmYNkDPPDtX1QbDBrjLSBJwr66GabdDh6DHG6vXwmeYNoG
2020-08-02T04:49:47.215113744Z [INFO]  dshop.utils.handleLog: Using IPFS gateway https://ipfs.ogn.app for fetching offer data
2020-08-02T04:49:47.21534627Z [INFO]  dshop.utils.handleLog: Fetching offer data with hash QmYNkDPPDtX1QbDBrjLSBJwr66GabdDh6DHG6vXwmeYNoG
2020-08-02T04:49:47.21873529Z [ERROR] dshop.queues.eventsProcessor: Log handler failed: IPFS gateway timeout
```

Notice that based on log timestamps, fetching the offer data from IPFS returned with a timeout immediately, despite the timeout being set to 60sec... I checked the content for that hash is available by logging into a server container and fetching the content.

It turns out there is a subtlety in the way memoize works for async functions. It caches the Promise. Therefore, if the Promise gets rejected (due to an IPFS timeout), all subsequent calls to the function for the same IPFS hash would return the same exception as opposed to trying to fetch the content again. Which explains why the queue retries all failed.

Fixed by adding a wrapper method that clears the memoize cache in case of an exception.

Also cleaned up Jsdoc for this file.