### PR TITLE
Use utf8 encoding for original charset for encrypted config

### DIFF
--- a/backend/test/config.test.js
+++ b/backend/test/config.test.js
@@ -1,0 +1,34 @@
+const crypto = require('crypto')
+const chai = require('chai')
+const expect = chai.expect
+
+const { IV_LENGTH, encrypt, decrypt } = require('../utils/encryptedConfig')
+
+describe('Encrypted config', () => {
+  it('should encrypt and decrypt ASCII', async () => {
+    const original = 'My name is job.'
+    const iv = crypto.randomBytes(IV_LENGTH)
+    const enc = encrypt(iv, original)
+    const dec = decrypt(iv, enc)
+
+    expect(dec).to.be.equal(original)
+  })
+
+  it('should encrypt and decrypt UTF-8', async () => {
+    const original = '街角杂货铺'
+    const iv = crypto.randomBytes(IV_LENGTH)
+    const enc = encrypt(iv, original)
+    const dec = decrypt(iv, enc)
+
+    expect(dec).to.be.equal(original)
+  })
+
+  it('should encrypt and decrypt UTF-8 with control', async () => {
+    const original = 'Something ♥️'
+    const iv = crypto.randomBytes(IV_LENGTH)
+    const enc = encrypt(iv, original)
+    const dec = decrypt(iv, enc)
+
+    expect(dec).to.be.equal(original)
+  })
+})

--- a/backend/utils/encryptedConfig.js
+++ b/backend/utils/encryptedConfig.js
@@ -68,7 +68,7 @@ function encrypt(iv, str) {
 
   const cypher = crypto.createCipheriv(CYPHER_ALGO, ENCRYPTION_KEY_HASH, iv)
 
-  msg.push(cypher.update(str, 'binary', 'hex'))
+  msg.push(cypher.update(str, 'utf8', 'hex'))
   msg.push(cypher.final('hex'))
 
   return msg.join('')
@@ -97,8 +97,8 @@ function decrypt(iv, enc) {
 
   const decypher = crypto.createDecipheriv('aes256', ENCRYPTION_KEY_HASH, iv)
 
-  msg.push(decypher.update(enc, 'hex', 'binary'))
-  msg.push(decypher.final('binary'))
+  msg.push(decypher.update(enc, 'hex', 'utf8'))
+  msg.push(decypher.final('utf8'))
 
   return msg.join('')
 }
@@ -328,6 +328,7 @@ async function dump(shopId) {
 }
 
 module.exports = {
+  IV_LENGTH,
   encrypt,
   encryptJSON,
   decrypt,


### PR DESCRIPTION
Fixes #358

Includes some tests.  This will chunk up some shops with utf-8 characters. There's 5 with no deployments and 2 are known broken.  The others can probably just be renamed and they'll be fine.