### PR TITLE
Update public and data URL when hostname gets updated

### DIFF
--- a/backend/routes/shops.js
+++ b/backend/routes/shops.js
@@ -21,7 +21,13 @@ const {
 } = require('./_auth')
 const { createSeller } = require('../utils/sellers')
 const { getConfig, setConfig } = require('../utils/encryptedConfig')
-const { createShop } = require('../utils/shop')
+const {
+  createShop,
+  getShopDataUrl,
+  getShopPublicUrl,
+  getPublicUrl,
+  getDataUrl
+} = require('../utils/shop')
 const genPGP = require('../utils/pgp')
 const get = require('lodash/get')
 const set = require('lodash/set')
@@ -364,11 +370,19 @@ module.exports = function (router) {
       name = json.fullTitle || json.title
     }
 
-    const zone = networkConfig.domain
-    const backend = networkConfig.backendUrl
-    const isLocal = zone === 'localhost'
-    const publicUrl = isLocal ? backend : `https://${hostname}.${zone}`
-    const dataUrl = `${publicUrl}/${dataDir}/`
+    // Construct the shop's public and data URLs.
+    const publicUrl = getPublicUrl(
+      hostname,
+      networkConfig.domain,
+      networkConfig.backendUrl
+    )
+    const dataUrl = getDataUrl(
+      hostname,
+      dataDir,
+      networkConfig.domain,
+      networkConfig.backendUrl
+    )
+
     const supportEmail = req.body.supportEmail || req.seller.email
 
     let defaultShopConfig = {}
@@ -482,7 +496,7 @@ module.exports = function (router) {
     }
 
     const netPath = `networks[${network.networkId}]`
-    shopConfig = set(shopConfig, `${netPath}.backend`, backend)
+    shopConfig = set(shopConfig, `${netPath}.backend`, networkConfig.backendUrl)
     if (req.body.listingId) {
       shopConfig = set(shopConfig, `${netPath}.listingId`, req.body.listingId)
     }
@@ -789,6 +803,8 @@ module.exports = function (router) {
         }
       }
 
+      const additionalOpts = {}
+
       // Check the hostname picked by the merchant is available.
       const existingConfig = getConfig(req.shop.config)
       if (req.body.hostname) {
@@ -804,12 +820,15 @@ module.exports = function (router) {
           })
         }
         req.shop.hostname = hostname
+
+        // Update the public and dataUrl in the shop's config to
+        // reflect a possible change to the hostname.
+        additionalOpts.publicUrl = getShopPublicUrl(req.shop, netConfig)
+        additionalOpts.dataUrl = getShopDataUrl(req.shop, netConfig)
       }
       if (req.body.fullTitle) {
         req.shop.name = req.body.fullTitle
       }
-
-      const additionalOpts = {}
 
       // Configure Stripe webhooks
       if (req.body.stripe === false) {

--- a/backend/test/listing.test.js
+++ b/backend/test/listing.test.js
@@ -74,7 +74,7 @@ describe('Listing', () => {
 
     // Check the listingId is correct in the shop's config.json
     const config = getTestShopJsonConfig(shop)
-    expect(config.listingId).to.equal(shop.listingId)
+    expect(config.networks[999].listingId).to.equal(shop.listingId)
   })
 
   it('It should not update the shop listingId', async () => {
@@ -156,6 +156,6 @@ describe('Listing', () => {
 
     // And the new shop's config should point to the proper listing id.
     const config = getTestShopJsonConfig(newShop)
-    expect(config.listingId).to.equal(newShop.listingId)
+    expect(config.networks[999].listingId).to.equal(newShop.listingId)
   })
 })

--- a/backend/test/shop.util.test.js
+++ b/backend/test/shop.util.test.js
@@ -1,0 +1,25 @@
+const chai = require('chai')
+const expect = chai.expect
+
+const { getShopDataUrl } = require('../utils/shop')
+
+describe('Shop Utils', () => {
+  it('should create a data URL', async () => {
+    // Prod environment.
+    const netConfig = {
+      domain: 'ogn.app'
+    }
+    const shop = {
+      hostname: 'foo',
+      authToken: 'bar'
+    }
+    let dataUrl = getShopDataUrl(shop, netConfig)
+    expect(dataUrl).to.be.equal('https://foo.ogn.app/bar/')
+
+    // Dev environment.
+    netConfig.domain = 'localhost'
+    netConfig.backendUrl = 'http://localhost:1234'
+    dataUrl = getShopDataUrl(shop, netConfig)
+    expect(dataUrl).to.be.equal('http://localhost:1234/bar/')
+  })
+})

--- a/backend/utils/shop.js
+++ b/backend/utils/shop.js
@@ -77,4 +77,65 @@ function findShopByHostname(req, res, next) {
   })
 }
 
-module.exports = { createShop, findShopByHostname }
+/**
+ * Get a shop's public URL. To be used before a shop is created.
+ * @param {string} hostname: Shop's hostname.
+ * @param {string} domain: Network domain or localhost on dev environment.
+ * @param {string} backendUrl: Url to the back-end. Only used in dev/test environment.
+ * @returns {string}
+ */
+function getPublicUrl(hostname, domain, backendUrl) {
+  const isLocal = domain === 'localhost'
+  return isLocal ? backendUrl : `https://${hostname}.${domain}`
+}
+
+/**
+ * Get a shop's data URL. To be used before a shop is created.
+ * @param {string} hostname: Shop's hostname.
+ * @param {string} dataDir: Name of the directory where the shop's data is stored.
+ * @param {string} domain: Network domain or localhost on dev environment.
+ * @param {string} backendUrl: Url to the back-end. Only used in dev/test environment.
+ * @returns {string}
+ */
+function getDataUrl(hostname, dataDir, domain, backendUrl) {
+  const publicUrl = getPublicUrl(hostname, domain, backendUrl)
+  return `${publicUrl}/${dataDir}/`
+}
+
+/**
+ * Get a shop's data URL.
+ * @param {models.Shop} shop
+ * @param {object} networkConfig: Network configuration.
+ * @returns {string}
+ */
+function getShopPublicUrl(shop, networkConfig) {
+  return getPublicUrl(
+    shop.hostname,
+    networkConfig.domain,
+    networkConfig.backendUrl
+  )
+}
+
+/**
+ * Get a shop's data URL.
+ * @param {models.Shop} shop
+ * @param {object} networkConfig: Network configuration.
+ * @returns {string}
+ */
+function getShopDataUrl(shop, networkConfig) {
+  return getDataUrl(
+    shop.hostname,
+    shop.authToken,
+    networkConfig.domain,
+    networkConfig.backendUrl
+  )
+}
+
+module.exports = {
+  createShop,
+  findShopByHostname,
+  getShopDataUrl,
+  getShopPublicUrl,
+  getDataUrl,
+  getPublicUrl
+}


### PR DESCRIPTION
We already had a few instances in prod where the backend payment processing failed because it could not load the shop's config.json (see this [code](https://github.com/OriginProtocol/dshop/blob/master/backend/utils/handleLog.js#L256)).
This was because the merchant had updated their shop's hostname and the dataUrl was still using the old hostname. 

This change updates the public and data URL every time a shop's config is saved.