### PR TITLE
Script to fix Stripe webhooks

### DIFF
--- a/backend/scripts/validatePayments.js
+++ b/backend/scripts/validatePayments.js
@@ -9,8 +9,17 @@
 // 3. Run the script locally.
 //    For example to validate payment data for shop Id 2:
 //       node validatePayments.js --type=payment --shopId=2
-//    To valide Stripe config for all the shops:
+//
+//    Validate Stripe config for all the shops:
 //       node validatePayments.js --type=config
+//
+//    Check Stripe webhook (does not fix it):
+//       node validatePayments.js --type=webhook --allShops
+//
+//    Check and fix Stripe webhook for all shops
+//       node validatePayments.js --type=webhook --allShops --doIt=true
+//
+
 const get = require('lodash/get')
 const stripeRaw = require('stripe')
 require('dotenv').config()
@@ -267,7 +276,7 @@ async function validateWebhooks() {
         }
 
         log.error(
-          `Missing metadata or invalid URL. Webhook id:${id} url:${url}`
+          `Shop ${shop.name} (${shop.id}): Missing metadata or invalid URL. Webhook id:${id} url:${url}`
         )
 
         // Delete the invalid Dshop webhook.

--- a/backend/utils/stripe.js
+++ b/backend/utils/stripe.js
@@ -230,6 +230,7 @@ async function webhookValidation(shop, config, backendUrl) {
 }
 
 module.exports = {
+  getWebhookData,
   normalizeDescriptor,
   deregisterWebhooks,
   registerWebhooks,


### PR DESCRIPTION
A recent changes added metadata to the webhooks but legacy webhooks were not updated.

This script goes thru all the shops and verifies if their webhook is properly configured.
If not, it deletes the invalid webhook and creates a new one.