### PR TITLE
Remove deprecated relationship between external_payments and orders table

### DIFF
--- a/backend/models/external_payment.js
+++ b/backend/models/external_payment.js
@@ -32,12 +32,5 @@ module.exports = (sequelize, DataTypes) => {
     }
   )
 
-  ExternalPayment.associate = function (models) {
-    ExternalPayment.belongsTo(models.Order, {
-      as: 'externalPayments',
-      foreignKey: 'orderId'
-    })
-  }
-
   return ExternalPayment
 }


### PR DESCRIPTION
The order_id was removed from external_payments a while back but the model still had a reference to it.

This was causing some errors in prod when the external_payments table was getting queried. For ex:
```
2020-09-02T18:26:14.807824507Z [ERROR] dshop.routes.stripe: ⚠️ Failed to send email { SequelizeDatabaseError: column "order_id" does not exist
2020-09-02T18:26:14.808090242Z       'SELECT "id", "created_at", "updated_at", "payment_at", "external_id", "data", "amount", "fee", "net", "currency", "authenticated", "payment_intent" AS "paymentIntent", "payment_code" AS "paymentCode", "type", "created_at" AS "createdAt", "updated_at" AS "updatedAt", "order_id" AS "orderId" FROM "external_payments" AS "ExternalPayment" WHERE "ExternalPayment"."authenticated" = true AND "ExternalPayment"."external_id" = \'evt_1HMivr4GKR0xedkasHjGsydu\' LIMIT 1;',
2020-09-02T18:26:14.808106503Z      parameters: undefined },
```