### PR TITLE
Fix order email link

### DIFF
--- a/backend/logic/order/order.js
+++ b/backend/logic/order/order.js
@@ -156,7 +156,13 @@ async function processNewOrder({
   // cause the order to get recorded multiple times in the DB.
   if (!skipEmail) {
     try {
-      await sendNewOrderEmail({ orderId: shortId, shop, cart: data, network })
+      await sendNewOrderEmail({
+        orderId: shortId,
+        order,
+        shop,
+        cart: data,
+        network
+      })
     } catch (e) {
       log.error('Email sending failure:', e)
       Sentry.captureException(e)

--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -158,6 +158,7 @@ module.exports = function (router) {
       try {
         await sendNewOrderEmail({
           orderId: req.params.orderId,
+          order: req.order,
           shop: req.shop,
           cart: JSON.parse(req.order.data)
         })

--- a/backend/scripts/one-off/offchainOrdersMigration.js
+++ b/backend/scripts/one-off/offchainOrdersMigration.js
@@ -80,7 +80,7 @@ async function main() {
       paymentCode: oldOrder.paymentCode,
       ipfsHash: oldOrder.ipfsHash,
       encryptedIpfsHash: oldOrder.encryptedIpfsHash,
-      offerId: oldOrder.offerId,
+      offerId: oldOrder.orderId,
       offerStatus: oldOrder.statusStr,
       createdBlock: oldOrder.createdBlock,
       updatedBlock: oldOrder.updatedBlock,

--- a/backend/utils/emails/newOrder.js
+++ b/backend/utils/emails/newOrder.js
@@ -123,7 +123,7 @@ async function sendNewOrderEmail({
     : `${publicURL}/order/${order.encryptedIpfsHash}?auth=${cart.dataKey}`
 
   // Link for the merchant to the orders admin page.
-  const orderUrlAdmin = `${networkConfig.backendUrl}/admin/orders/${orderId}`
+  const orderUrlAdmin = `${networkConfig.backendUrl}/#/admin/orders/${orderId}`
 
   const subject = shopConfig.emailSubject || `Your ${shop.name} order`
 

--- a/backend/utils/printful.js
+++ b/backend/utils/printful.js
@@ -358,6 +358,7 @@ const processShippedEvent = async (event, shopId) => {
 
     await sendNewOrderEmail({
       orderId,
+      order: dbOrder,
       shop,
       cart: dbOrder.data,
       varsOverride: {

--- a/shop/src/utils/useOrigin.js
+++ b/shop/src/utils/useOrigin.js
@@ -102,6 +102,8 @@ const marketplaceAbi = [
 
 const marketplaceInterface = new ethers.utils.Interface(marketplaceAbi)
 
+// Loads offer data from either the tx hash for the marketplace offer
+// or from the IPFS hash of the encrypted offer data.
 async function getOfferFromTx({ tx, password, config, provider, marketplace }) {
   let encryptedHash, fullOfferId, offer
 
@@ -146,6 +148,8 @@ async function getOfferFromTx({ tx, password, config, provider, marketplace }) {
 
     offer = await marketplace.offers(listingId, offerId)
   } else {
+    // The tx parameter is not a transaction hash but rather the
+    // IPFS hash of the encrypted offer.
     encryptedHash = tx
   }
 


### PR DESCRIPTION
Fix for bug #544 

If the order is off-chain (e.g. order.offerId is undefined), the order page presented to the buyer should load its data directly from the encrypted IPFS blob.

Note: also includes an unrelated small fix to the offchainOrdersMigration.js script.