### PR TITLE
Fix #562

### DIFF
--- a/shop/src/pages/checkout/Shipping.js
+++ b/shop/src/pages/checkout/Shipping.js
@@ -19,7 +19,11 @@ function isActive(zone, cart) {
 const CheckoutShipping = () => {
   const { config } = useConfig()
   const [{ cart }, dispatch] = useStateValue()
-  const { shippingZones, loading } = useFlattenedShippingZones()
+  const {
+    shippingZones,
+    loading,
+    error: shippingZonesError
+  } = useFlattenedShippingZones()
   const currencyOpts = useCurrencyOpts()
 
   const country = get(cart, 'userInfo.country')
@@ -30,7 +34,11 @@ const CheckoutShipping = () => {
   const filteredShippingZones = shippingZones.filter(
     (zone) => (zone.countries || []).indexOf(countryCode) >= 0
   )
-  if (!filteredShippingZones.length && defaultShippingZone) {
+  if (
+    !shippingZonesError &&
+    !filteredShippingZones.length &&
+    defaultShippingZone
+  ) {
     filteredShippingZones.push(defaultShippingZone)
   }
 
@@ -104,10 +112,11 @@ const CheckoutShipping = () => {
               Loading shipping costs...
             </fbt>
           </div>
-        ) : !filteredShippingZones.length ? (
+        ) : shippingZonesError || !filteredShippingZones.length ? (
           <div className="p-3">
             <fbt desc="checkout.shipping.loadError">
-              Sorry, there was an error calculating shipping costs.
+              Sorry, there was an error calculating shipping costs. Try
+              refreshing the page.
             </fbt>
           </div>
         ) : (

--- a/shop/src/utils/useShippingZones.js
+++ b/shop/src/utils/useShippingZones.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import get from 'lodash/get'
 
 import { useStateValue } from 'data/state'
 
@@ -8,10 +9,26 @@ function useShippingZones() {
   const { config } = useConfig()
   const [{ shippingZones, cart, reload }, dispatch] = useStateValue()
   const [loading, setLoading] = useState(true)
+  const [configLoading, setConfigLoading] = useState(true)
   const [error, setError] = useState(false)
+
+  const userInfo = get(cart, 'userInfo')
+  const items = get(cart, 'items')
+
+  useEffect(() => {
+    if (!configLoading || !userInfo || !items) {
+      return
+    }
+
+    setConfigLoading(false)
+  }, [userInfo, items, configLoading])
 
   useEffect(() => {
     async function fetchShippingZones() {
+      if (configLoading) {
+        return
+      }
+
       setLoading(true)
       let zones = []
       try {
@@ -50,7 +67,7 @@ function useShippingZones() {
     }
 
     fetchShippingZones()
-  }, [reload.shippingZones])
+  }, [configLoading, reload.shippingZones])
 
   return { shippingZones, loading, error }
 }


### PR DESCRIPTION
`recipient` sent to the shipping API endpoint was sometimes `undefined` if config takes sometime loading. This surfaces that error instead of showing "Free shipping"