### PR TITLE
Fix paymentType bug for on-chain transactions

### DIFF
--- a/backend/utils/handleLog.js
+++ b/backend/utils/handleLog.js
@@ -180,6 +180,13 @@ async function _processEventForNewOrder({
   const offer = JSON.parse(offerData)
   log.debug('Offer:', offer)
 
+  // Load the encrypted data.
+  const encryptedHash = offer.encryptedData
+  if (!encryptedHash) {
+    throw new Error('No encrypted data found')
+  }
+  log.info(`Fetching encrypted offer data with hash ${encryptedHash}`)
+
   const order = await processNewOrder({
     network,
     networkConfig,


### PR DESCRIPTION
A new paymentType argument was added to the processNewOrder logic method but in case of an on-chain transaction (e.g. marketplace transaction), it was not passed. Causing the paymentType column to remain blank for those orders in the DB.