### PR TITLE
Adds some deployment text to confirmation modal

### DIFF
--- a/shop/src/components/ConfirmationModal.js
+++ b/shop/src/components/ConfirmationModal.js
@@ -9,6 +9,7 @@ import { Spinner } from 'components/icons/Admin'
 const AdminConfirmationModal = ({
   className = 'btn btn-outline-primary',
   confirmedText = fbt('Success', 'success'),
+  confirmedSubText,
   confirmText = fbt('Are you sure?', 'areYouSure'),
   onConfirm,
   onSuccess,
@@ -125,6 +126,9 @@ const AdminConfirmationModal = ({
             ) : state.confirmed ? (
               <>
                 <div className="text-lg">{confirmedText}</div>
+                {confirmedSubText ? (
+                  <div className="text-sm mt-3">{confirmedSubText}</div>
+                ) : null}
                 <div className="actions">
                   <button
                     className="btn btn-primary px-5"

--- a/shop/src/pages/admin/settings/deployments/_DeployButton.js
+++ b/shop/src/pages/admin/settings/deployments/_DeployButton.js
@@ -26,7 +26,7 @@ const AdminDeployShop = ({
         'admin.settings.deployments.publishedText'
       )}
       confirmedSubText={fbt(
-        "We're in the process of deploying your shop to a global content distribution network and the Interplanetary Flie System (IPFS). It may take up to 15 minutes for all changes to take effect. Please be patient.",
+        "We're in the process of deploying your shop to a global content distribution network and the Interplanetary File System (IPFS). It may take up to 15 minutes for all changes to take effect. Please be patient.",
         'admin.settings.deployments.confirmedSubText'
       )}
       loadingText={`${fbt('Publishing', 'Publishing')}...`}

--- a/shop/src/pages/admin/settings/deployments/_DeployButton.js
+++ b/shop/src/pages/admin/settings/deployments/_DeployButton.js
@@ -25,6 +25,10 @@ const AdminDeployShop = ({
         'Your changes have been successfully published.',
         'admin.settings.deployments.publishedText'
       )}
+      confirmedSubText={fbt(
+        "We're in the process of deploying your shop to a global content distribution network and the Interplanetary Flie System (IPFS). It may take up to 15 minutes for all changes to take effect. Please be patient.",
+        'admin.settings.deployments.confirmedSubText'
+      )}
       loadingText={`${fbt('Publishing', 'Publishing')}...`}
       spinner={true}
       onConfirm={() => {


### PR DESCRIPTION
Adds a little expectation management for short term improvement of #683.

![confirmed_subtext](https://user-images.githubusercontent.com/1048089/97062275-71c4e800-1557-11eb-8d62-93303604aa00.png)

Let me know if you have any feedback for verbiage or formatting.