### PR TITLE
Disable CDN deployments

### DIFF
--- a/backend/utils/const.js
+++ b/backend/utils/const.js
@@ -85,6 +85,9 @@ const THEMES_CACHE = IS_TEST
   ? TEST_THEMES_CACHE
   : process.env.THEMES_CACHE || `${__dirname}/../themes`
 
+// TODO: This is temporary
+const ENABLE_CDN = process.env.ENABLE_CDN === 'true'
+
 module.exports = {
   CONTRACTS,
   ENCRYPTION_KEY,
@@ -109,6 +112,7 @@ module.exports = {
   PROTOCOL_LABS_GATEWAY,
   PINATA_API,
   PINATA_GATEWAY,
+  ENABLE_CDN,
   BUCKET_PREFIX,
   SERVICE_PREFIX
 }

--- a/backend/utils/dns/clouddns.js
+++ b/backend/utils/dns/clouddns.js
@@ -258,20 +258,19 @@ async function setRecords({
   })
   const existingTXT = get(existingTXTRecords, '[0][0]')
 
+  // Delete all A records with this name
+  if (existingAs && existingAs.length > 0) {
+    for (const arec of existingARecords) {
+      changes.push(await deleteRecord(arec, zoneObj))
+    }
+  }
+
   // If we got an IP address, we're creating an A record
   if (ipAddresses) {
     // Delete the CNAME records with this name
     if (existingCNAME) {
       log.debug(`Will delete CNAME for ${fqSubdomain}`)
       changes.push(await deleteRecord(existingCNAME, zoneObj))
-    }
-
-    // Delete all A records with this name
-    if (existingAs && existingAs.length > 0) {
-      log.debug(`Will delete A records for ${fqSubdomain}`)
-      for (const arec of existingAs) {
-        changes.push(await deleteRecord(arec, zoneObj))
-      }
     }
 
     // Create an A record for each IP we get


### PR DESCRIPTION
Not ready to deploy this just yet(still looking for alternatives), and hopefully this is only temporary but I want it ready to go before we hit the next quota.

That said, it's looking increasingly likely that Cloud CDN deployments aren't going to work out near-term so this PR disables them.  Already deployed shops will continue to work fine and move back over the the IPFS gateway upon next deployment.

Bucket deployments will continue to happen, and any custom domains already pointing at a GCP balancer will continue to work, until we decide its necessary to clean up the Cloud CDN/load balancer resources.