### PR TITLE
Optional CDN deployments per shop

### DIFF
--- a/backend/db/migrations/20201020191102-add-shop-domain-ip.js
+++ b/backend/db/migrations/20201020191102-add-shop-domain-ip.js
@@ -6,10 +6,7 @@ module.exports = {
       type: Sequelize.STRING
     })
   },
-
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.removeColumn('shop_domains', 'ip_address', { 
-      type: Sequelize.STRING
-    })
+  down: (queryInterface) => {
+    return queryInterface.removeColumn('shop_domains', 'ip_address')
   }
 }

--- a/backend/db/migrations/20201028181012-add-cdn-option.js
+++ b/backend/db/migrations/20201028181012-add-cdn-option.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('shops', 'enable_cdn', { 
+      type: Sequelize.BOOLEAN,
+      defaultValue: false
+    })
+  },
+  down: (queryInterface) => {
+    return queryInterface.removeColumn('shops', 'enable_cdn')
+  }
+}

--- a/backend/logic/deploy/index.js
+++ b/backend/logic/deploy/index.js
@@ -250,22 +250,25 @@ async function deploy({
    * Configure the CDN(s) to point at bucket(s)
    */
   let ipAddresses = null
-  log.info(`Configuring CDN...`)
-  try {
-    const responses = await cdnConfig({
-      networkConfig,
-      shop,
-      deployment,
-      domains: [fqdn]
-    })
-    if (responses.length > 0) {
-      ipAddresses = responses.map((r) => r.ipAddress)
+  if (shop.enableCdn) {
+    log.info(`Configuring CDN...`)
+
+    try {
+      const responses = await cdnConfig({
+        networkConfig,
+        shop,
+        deployment,
+        domains: [fqdn]
+      })
+      if (responses.length > 0) {
+        ipAddresses = responses.map((r) => r.ipAddress)
+      }
+    } catch (err) {
+      log.error(`Unknown error configuring CDN.`)
+      log.error(err)
+      await failDeployment(deployment, 'Failed to configure CDN')
+      return error(ERROR_GENERAL)
     }
-  } catch (err) {
-    log.error(`Unknown error configuring CDN.`)
-    log.error(err)
-    await failDeployment(deployment, 'Failed to configure CDN')
-    return error(ERROR_GENERAL)
   }
 
   /**

--- a/backend/models/shop.js
+++ b/backend/models/shop.js
@@ -26,7 +26,11 @@ module.exports = (sequelize, DataTypes) => {
       firstBlock: DataTypes.INTEGER,
       lastBlock: DataTypes.INTEGER,
       // True if the shop has changes that requires to get published.
-      hasChanges: DataTypes.BOOLEAN
+      hasChanges: DataTypes.BOOLEAN,
+      enableCdn: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false
+      }
     },
     {
       underscored: true,

--- a/backend/utils/dns/clouddns.js
+++ b/backend/utils/dns/clouddns.js
@@ -258,20 +258,19 @@ async function setRecords({
   })
   const existingTXT = get(existingTXTRecords, '[0][0]')
 
+  // Delete all A records with this name
+  if (existingAs && existingAs.length > 0) {
+    for (const arec of existingARecords) {
+      changes.push(await deleteRecord(arec, zoneObj))
+    }
+  }
+
   // If we got an IP address, we're creating an A record
   if (ipAddresses) {
     // Delete the CNAME records with this name
     if (existingCNAME) {
       log.debug(`Will delete CNAME for ${fqSubdomain}`)
       changes.push(await deleteRecord(existingCNAME, zoneObj))
-    }
-
-    // Delete all A records with this name
-    if (existingAs && existingAs.length > 0) {
-      log.debug(`Will delete A records for ${fqSubdomain}`)
-      for (const arec of existingAs) {
-        changes.push(await deleteRecord(arec, zoneObj))
-      }
     }
 
     // Create an A record for each IP we get


### PR DESCRIPTION
Adds per-shop CDN opt-in, currently to be enabled via direct DB access.

I'm not sure where the UI would this should lay so I'm leaving that for later.  Perhaps in super-admin?  I imagine this decision should be by whoever is providing the infra.

This replaces #709 