### PR TITLE
Fix NaN bug in CDN deployment

### DIFF
--- a/backend/logic/deploy/cdn/gcp.js
+++ b/backend/logic/deploy/cdn/gcp.js
@@ -855,7 +855,7 @@ function lastSortedName(names) {
 function incrementName(name, baseName) {
   const strSuffix = trimStart(name.replace(baseName, ''), '-')
   let suffix = 0
-  if (strSuffix) {
+  if (strSuffix && !Number.isNaN(Number(strSuffix))) {
     suffix = Number(strSuffix) + 1
   }
   return `${baseName}-${suffix}`


### PR DESCRIPTION
`Number(strSuffix)` returns a `NaN` in some cases making the certificate name `ds-deploy-mainnet-xxx-NaN` which fails the regex test on Google's side (because it contains uppercase character)

[Related logs](https://console.cloud.google.com/logs/query;pinnedLogId=2020-10-29T10:32:14.445049333Z%2Fbdnup4uigqupfwd5a;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22origin-214503%22%0Aresource.labels.location%3D%22us-west1-a%22%0Aresource.labels.cluster_name%3D%22origin%22%0Aresource.labels.namespace_name%3D%22experimental%22%0Alabels.k8s-pod%2Fapp%3D%22experimental-dshop-backend-mainnet%22;timeRange=PT1H?project=origin-214503)