### PR TITLE
Cleanup disconnect logic

### DIFF
--- a/backend/logic/printful/webhook.js
+++ b/backend/logic/printful/webhook.js
@@ -58,7 +58,15 @@ const registerPrintfulWebhook = async (shopId, shopConfig, backendUrl) => {
  * @throws
  */
 const deregisterPrintfulWebhook = async (shopId, shopConfig) => {
+  if (!shopConfig.printfulWebhookSecret) {
+    log.info(`[Shop ${shopId}] No webhook registered`)
+    return
+  }
+
   const apiKey = shopConfig.printful
+  if (!apiKey) {
+    throw new Error('Printful API key not configured.')
+  }
 
   let error
   try {

--- a/backend/logic/printful/webhook.js
+++ b/backend/logic/printful/webhook.js
@@ -73,7 +73,7 @@ const deregisterPrintfulWebhook = async (shopId, shopConfig) => {
     const resp = await fetch(apiKey, '/webhooks', 'DELETE')
     const respJSON = await resp.json()
     if (resp.ok) {
-      log.info('Shop ${shopId} - De-registered printful webhook')
+      log.info(`Shop ${shopId} - De-registered printful webhook`)
     } else {
       error = JSON.stringify(respJSON)
     }

--- a/backend/logic/shop/config.js
+++ b/backend/logic/shop/config.js
@@ -391,7 +391,7 @@ async function updateShopConfig({ seller, shop, data }) {
     await deregisterPrintfulWebhook(shopId, existingConfig)
 
     // Reset all the Printful related fields in the shop's DB config.
-    log.info(`[Shop ${shopId}] Clearing PayPal fields in the shop's config`)
+    log.info(`[Shop ${shopId}] Clearing Printful fields in the shop's config`)
     dataOverride.printful = ''
     dataOverride.printfulWebhookSecret = ''
     dataOverride.printfulAutoFulfill = false

--- a/backend/logic/shop/config.js
+++ b/backend/logic/shop/config.js
@@ -47,7 +47,6 @@ const dbConfigOptionalKeys = [
   'mailgunSmtpServer',
   'offlinePaymentMethods',
   'password',
-  'paypal',
   'paypalClientId',
   'paypalClientSecret',
   'paypalWebhookHost',
@@ -297,13 +296,11 @@ async function updateShopConfig({ seller, shop, data }) {
   // Configure Stripe
   //
   if (data.stripe) {
-    log.info(`Shop ${shopId} - Registering Stripe webhook`)
-
+    log.info(`[Shop ${shopId}] Registering Stripe webhook`)
     const validKeys = validateStripeKeys({
       publishableKey: data.stripeKey,
       secretKey: data.stripeBackend
     })
-
     if (!validKeys) {
       return { success: false, reason: 'Invalid Stripe credentials' }
     }
@@ -315,11 +312,12 @@ async function updateShopConfig({ seller, shop, data }) {
       data.stripeWebhookHost || netConfig.backendUrl
     )
     dataOverride.stripeWebhookSecret = secret
-  } else if (existingConfig.stripeBackend && data.stripe === false) {
-    log.info(`Shop ${shopId} - De-registering Stripe webhook`)
+  } else if (data.disconnectStripe === true) {
+    // De-register any webhook.
     await stripeUtils.deregisterWebhooks(shop, existingConfig)
 
     // Reset all the Stripe related fields in the shop's DB config.
+    log.info(`[Shop ${shopId}] Clearing Stripe fields in the shop's config`)
     dataOverride.stripeWebhookSecret = ''
     dataOverride.stripeWebhookHost = ''
     dataOverride.stripeBackend = ''
@@ -329,7 +327,7 @@ async function updateShopConfig({ seller, shop, data }) {
   // Configure PayPal
   ///
   if (data.paypal) {
-    log.info(`Shop ${shopId} - Registering PayPal webhook`)
+    log.info(`[Shop ${shopId}] Registering PayPal webhook`)
     const client = paypalUtils.getClient(
       netConfig.paypalEnvironment,
       data.paypalClientId,
@@ -349,12 +347,12 @@ async function updateShopConfig({ seller, shop, data }) {
       netConfig
     )
     dataOverride.paypalWebhookId = result.webhookId
-  } else if (existingConfig.paypal && data.paypal === false) {
-    log.info(`Shop ${shopId} - De-registering PayPal webhook`)
-
+  } else if (data.disconnectPaypal === true) {
+    // De-register any webhook.
     await paypalUtils.deregisterWebhook(shopId, existingConfig, netConfig)
 
     // Reset all the Paypal related fields in the shop's DB config.
+    log.info(`[Shop ${shopId}] Clearing PayPal fields in the shop's config`)
     dataOverride.paypalClientId = ''
     dataOverride.paypalClientSecret = ''
     dataOverride.paypalWebhookHost = ''
@@ -380,7 +378,7 @@ async function updateShopConfig({ seller, shop, data }) {
   // Configure Printful
   //
   if (data.printful) {
-    log.info(`Shop ${shopId} - Registering Printful webhook`)
+    log.info(`[Shop ${shopId}] Registering Printful webhook`)
     const printfulWebhookSecret = await registerPrintfulWebhook(
       shopId,
       { ...existingConfig, ...data },
@@ -388,11 +386,12 @@ async function updateShopConfig({ seller, shop, data }) {
     )
 
     dataOverride.printfulWebhookSecret = printfulWebhookSecret
-  } else if (existingConfig.printful && !data.printful) {
-    log.info(`Shop ${shopId} - De-registering Printful webhook`)
+  } else if (data.disconnectPrintful === true) {
+    // De-register any webhook.
     await deregisterPrintfulWebhook(shopId, existingConfig)
 
     // Reset all the Printful related fields in the shop's DB config.
+    log.info(`[Shop ${shopId}] Clearing PayPal fields in the shop's config`)
     dataOverride.printful = ''
     dataOverride.printfulWebhookSecret = ''
     dataOverride.printfulAutoFulfill = false
@@ -401,7 +400,7 @@ async function updateShopConfig({ seller, shop, data }) {
   //
   // Update the configs on disk.
   //
-  log.info(`Shop ${shopId} - Saving config on disk.`)
+  log.info(`[Shop ${shopId}] Saving config on disk.`)
 
   // Save config.json on disk.
   if (Object.keys(jsonConfig).length || Object.keys(jsonNetConfig).length) {
@@ -446,7 +445,7 @@ async function updateShopConfig({ seller, shop, data }) {
   //
   // Save the config in the DB.
   //
-  log.info(`Shop ${shopId} - Saving config in the DB.`)
+  log.info(`[Shop ${shopId}] Saving config in the DB.`)
   const shopConfigFields = pick(
     { ...existingConfig, ...data, ...dataOverride },
     dbConfigKeys
@@ -467,7 +466,7 @@ async function updateShopConfig({ seller, shop, data }) {
     createdAt: Date.now()
   })
 
-  log.info(`Shop ${shopId} - config updated. Diff keys: ${diffKeys}`)
+  log.info(`[Shop ${shopId}] config updated. Diff keys: ${diffKeys}`)
   return { success: true }
 }
 

--- a/backend/utils/paypal.js
+++ b/backend/utils/paypal.js
@@ -138,6 +138,14 @@ const deregisterWebhook = async (shopId, shopConfig, netConfig) => {
   }
 
   const { paypalClientId, paypalClientSecret, paypalWebhookId } = shopConfig
+  if (!paypalWebhookId) {
+    log.info(`[Shop ${shopId}] No PayPal webhook configured.`)
+    return true
+  }
+  if (!paypalClientId || !paypalClientSecret) {
+    log.error(`[Shop ${shopId}] Invalid PayPal configuration.`)
+    return false
+  }
 
   try {
     const paypalEnv = netConfig.paypalEnvironment
@@ -146,9 +154,7 @@ const deregisterWebhook = async (shopId, shopConfig, netConfig) => {
     const request = new WebhookDeleteRequest(paypalWebhookId)
     await client.execute(request)
 
-    log.debug(
-      `[Shop ${shopId}] Deregistered paypal webhook, ${paypalWebhookId}`
-    )
+    log.info(`[Shop ${shopId}] Deregistered paypal webhook, ${paypalWebhookId}`)
     return true
   } catch (err) {
     log.error(

--- a/backend/utils/stripe.js
+++ b/backend/utils/stripe.js
@@ -77,7 +77,7 @@ async function deregisterWebhooks(shop, config) {
   const { stripeBackend, stripeWebhookSecret } = config
 
   if (!stripeBackend || !stripeWebhookSecret) {
-    log.debug(`[Shop ${shop.id}] Missing params, skipping deregistering`)
+    log.debug(`[Shop ${shop.id}] No webhook registered`)
     return
   }
 
@@ -107,7 +107,9 @@ async function deregisterWebhooks(shop, config) {
       }
     }
 
-    log.debug(`${endpointsToDelete.length} webhooks deregisterd`)
+    log.info(
+      `[Shop ${shop.id}] ${endpointsToDelete.length} webhooks deregisterd`
+    )
   } catch (err) {
     log.error(`[Shop ${shop.id}] Failed to deregister webhooks`, err)
     return { success: false }

--- a/shop/src/pages/admin/settings/payments/_DisconnectModal.js
+++ b/shop/src/pages/admin/settings/payments/_DisconnectModal.js
@@ -27,7 +27,7 @@ const DisconnectModal = ({ processor, className = '', afterDelete }) => {
         switch (processor.id) {
           case 'stripe':
             updatedConfig = {
-              stripe: false,
+              disconnectStripe: true,
               stripeKey: '',
               stripeBackend: '',
               stripeWebhookSecret: '',
@@ -48,6 +48,7 @@ const DisconnectModal = ({ processor, className = '', afterDelete }) => {
             break
           case 'printful':
             updatedConfig = {
+              disconnectPrintful: true,
               printful: '',
               printfulAutoFulfill: false,
               shippingApi: false
@@ -80,7 +81,7 @@ const DisconnectModal = ({ processor, className = '', afterDelete }) => {
             break
           case 'paypal':
             updatedConfig = {
-              paypal: false,
+              disconnectPaypal: true,
               paypalClientId: '',
               paypalClientSecret: ''
             }


### PR DESCRIPTION
I introduced a bug where Printful would get disconnected upon a config update :(

This should hopefully fix the issue and clean up our disconnect logic which was a bit confusing for a newbie like myself.
The main change is for the front-end disconnect modal to explicitly specify if an app should be disconnected as opposed to relying on the back-end figuring it out if the config change is related to connecting or disconnecting an app.