### PR TITLE
Improve diagnose tool to detect Stripe webhook with invalid metadata

### DIFF
--- a/backend/logic/payments/stripe.js
+++ b/backend/logic/payments/stripe.js
@@ -23,11 +23,11 @@ const { getConfig } = require('../../utils/encryptedConfig')
  */
 async function checkStripeConfig(shop, shopConfig, networkConfig) {
   if (!shopConfig.stripeBackend) {
-    log.info(`Shop ${shop.id} - Stripe not configured`)
+    log.info(`[Shop ${shop.id}] Stripe not configured`)
     return { success: true }
   }
 
-  log.info(`Shop ${shop.id} - Checking Stripe config`)
+  log.info(`[Shop ${shop.id}] Checking Stripe config`)
   let success = false
   try {
     success = await webhookValidation(
@@ -36,7 +36,7 @@ async function checkStripeConfig(shop, shopConfig, networkConfig) {
       shopConfig.stripeWebhookHost || networkConfig.backendUrl
     )
   } catch (e) {
-    log.error(`Shop ${shop.id} - Failed checking Stripe webhook config: ${e}`)
+    log.error(`[Shop ${shop.id}] Failed checking Stripe webhook config: ${e}`)
   }
 
   if (success) {

--- a/backend/logic/printful/webhook.js
+++ b/backend/logic/printful/webhook.js
@@ -108,7 +108,7 @@ const checkPrintfulWebhook = async (shopId, shopConfig, networkConfig) => {
     const resp = await fetch(apiKey, '/webhooks', 'GET')
     respJson = await resp.json()
     if (!resp.ok) {
-      error = respJson
+      error = JSON.stringify(respJson)
     }
   } catch (err) {
     error = err.message

--- a/backend/logic/shop/health.js
+++ b/backend/logic/shop/health.js
@@ -259,11 +259,7 @@ async function diagnoseShop(shop) {
 
   // Check Stripe configuration.
   if (shopConfig.stripeBackend) {
-    const stripeCheck = await checkStripeConfig(
-      shop.id,
-      shopConfig,
-      networkConfig
-    )
+    const stripeCheck = await checkStripeConfig(shop, shopConfig, networkConfig)
     if (stripeCheck.success) {
       diagnostic.stripe = { status: 'OK' }
     } else {

--- a/backend/routes/stripe.js
+++ b/backend/routes/stripe.js
@@ -85,9 +85,11 @@ module.exports = function (router) {
     )
 
     if (!web3Pk || !valid) {
-      log.error(
-        `[Shop ${req.shop.id}] Failed to make payment on Stripe, invalid/missing credentials`
-      )
+      const error = `[Shop ${req.shop.id}] Failed to make payment on Stripe: `
+      const reason = !web3Pk
+        ? 'Missing web3pk'
+        : 'Invalid webhook configuration'
+      log.error(error + reason)
       return res.status(400).send({
         success: false,
         message: 'CC payments unavailable'
@@ -120,7 +122,7 @@ module.exports = function (router) {
       json = JSON.parse(bodyText)
 
       /**
-       * Probably not a payment created by Dshop or one we can't do aything
+       * Probably not a payment created by Dshop or one we can't do anything
        * with. We should fail gracefully here so we can coexist with other
        * payment software on the same Stripe account/key.  Otherwise, it will
        * appear to be errors to Stripe and they will alert the user.

--- a/backend/scripts/configCli.js
+++ b/backend/scripts/configCli.js
@@ -205,7 +205,7 @@ async function checkStripe(network, shops) {
     log.info(`Checking Stripe config for shop ${shop.id} ${shop.name}`)
     const shopConfig = getConfig(shop.config)
     const { success, error } = await checkStripeConfig(
-      shop.id,
+      shop,
       shopConfig,
       networkConfig
     )

--- a/backend/utils/stripe.js
+++ b/backend/utils/stripe.js
@@ -193,8 +193,8 @@ async function registerWebhooks(shop, newConfig, oldConfig, backendUrl) {
 /**
  * Validates shop's webhook, if it exists
  * @param {Model.Shop} shop
- * @param {Model.Shop.config} config encrypted shop config
- * @param {String} backendUrl webhook host to use
+ * @param {Object} config: Shop's config
+ * @param {String} backendUrl: webhook host to use
  *
  * @returns {Boolean} true, if webhook exists and is configured correctly
  */
@@ -205,7 +205,6 @@ async function webhookValidation(shop, config, backendUrl) {
   if (!stripeBackend) return false
 
   let valid = false
-
   try {
     const stripe = Stripe(stripeBackend)
     const webhookEndpoints = await stripe.webhookEndpoints.list({
@@ -217,6 +216,9 @@ async function webhookValidation(shop, config, backendUrl) {
     )
 
     if (!existingWebhook) {
+      log.debug(
+        `[Shop ${shop.id}] No webhook with metadata.dshopStore matching authToken found`
+      )
       return valid
     }
 


### PR DESCRIPTION
Updated the diagnose logic and configCli to use the method webhookValidation() which performs a check on the validity of the webhook's metadata (makes sure it matches the shop's authToken).

Also small misc cleanups.