### PR TITLE
Serve dapp from backend if given a deployed hostname

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -122,7 +122,6 @@ router.get('/', async (req, res) => {
         .readFileSync(`${DSHOP_CACHE}/${authToken}/public/index.html`)
         .toString()
     } catch (e) {
-      // TODO: 404?
       return res.status(404).send('')
     }
   } else {

--- a/backend/app.js
+++ b/backend/app.js
@@ -11,6 +11,7 @@ const kebabCase = require('lodash/kebabCase')
 
 const { getConfig } = require('./utils/encryptedConfig')
 const { sequelize, Network } = require('./models')
+const hostCache = require('./utils/hostCache')
 const { getLogger } = require('./utils/logger')
 const { IS_PROD, DSHOP_CACHE } = require('./utils/const')
 const { Sentry, sentryEventPrefix } = require('./sentry')
@@ -71,7 +72,6 @@ app.use((req, res, next) => {
   return jsonBodyParser(req, res, next)
 })
 
-app.use(serveStatic(`${__dirname}/dist`, { index: false }))
 app.use('/theme', serveStatic(`${__dirname}/themes`, { index: false }))
 
 // Use express-promise-router which allows middleware to return promises.
@@ -114,18 +114,30 @@ async function getNetworkName() {
 
 router.get('/', async (req, res) => {
   let html
-  try {
-    html = fs.readFileSync(`${__dirname}/dist/index.html`).toString()
-  } catch (e) {
-    return res.send('')
+  const authToken = await hostCache(req.hostname)
+
+  if (authToken) {
+    try {
+      html = fs
+        .readFileSync(`${DSHOP_CACHE}/${authToken}/public/index.html`)
+        .toString()
+    } catch (e) {
+      // TODO: 404?
+      return res.status(404).send('')
+    }
+  } else {
+    try {
+      html = fs.readFileSync(`${__dirname}/dist/index.html`).toString()
+    } catch (e) {
+      return res.send('')
+    }
+
+    const NETWORK = await getNetworkName()
+    html = html
+      .replace('DATA_DIR', '')
+      .replace('TITLE', 'Origin Dshop')
+      .replace(/NETWORK/g, NETWORK)
   }
-
-  const NETWORK = await getNetworkName()
-  html = html
-    .replace('DATA_DIR', '')
-    .replace('TITLE', 'Origin Dshop')
-    .replace(/NETWORK/g, NETWORK)
-
   res.send(html)
 })
 
@@ -155,13 +167,28 @@ router.get('/theme/:theme', async (req, res) => {
 })
 
 router.get('*', async (req, res, next) => {
+  const authToken = await hostCache(req.hostname)
   const split = req.path.split('/')
-  if (split.length <= 2) {
+
+  if (!authToken && split.length <= 2) {
     return next()
   }
-  const dataDir = decodeURIComponent(split[1])
-  const dir = `${DSHOP_CACHE}/${dataDir}/data`
-  req.url = split.slice(2).join('/')
+
+  /**
+   * We're making some decisions on what source we're serving from here.
+   *
+   * 1) If the authToken was included in the URL, it's a data dir access.
+   * 2) If it's a known deployed hostname, we want to serve the assembled shop.
+   * 3) If all else failed, it's the admin
+   */
+  const partInUrl = decodeURIComponent(split[1])
+  const dataDir = authToken ? authToken : decodeURIComponent(split[1])
+  const isNamedDataAccess =
+    partInUrl === authToken || (!!partInUrl && !authToken)
+  const dir = `${DSHOP_CACHE}/${dataDir}${
+    isNamedDataAccess ? '/data' : '/public'
+  }`
+  req.url = isNamedDataAccess ? split.slice(2).join('/') : req.path
 
   // When serving config.json from backend, override active network settings.
   // This prevents problems when, eg, the backend specified in config.json does

--- a/backend/db/migrations/20201030222628-add-domain-index.js
+++ b/backend/db/migrations/20201030222628-add-domain-index.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.addIndex('shop_domains', ['domain'])
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.removeIndex('shop_domains', ['domain'])
+  }
+}

--- a/backend/scripts/aws/marketplace/startup_script.sh
+++ b/backend/scripts/aws/marketplace/startup_script.sh
@@ -153,6 +153,7 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';
+            proxy_set_header X-Forwarded-Host $host;
             proxy_set_header Host $host;
             proxy_cache_bypass $http_upgrade;
             proxy_connect_timeout       300;

--- a/backend/scripts/gcp/marketplace/startup_script.sh
+++ b/backend/scripts/gcp/marketplace/startup_script.sh
@@ -153,6 +153,7 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';
+            proxy_set_header X-Forwarded-Host $host;
             proxy_set_header Host $host;
             proxy_cache_bypass $http_upgrade;
             proxy_connect_timeout       300;

--- a/backend/utils/const.js
+++ b/backend/utils/const.js
@@ -1,3 +1,4 @@
+const path = require('path')
 require('dotenv').config()
 const randomstring = require('randomstring')
 
@@ -77,9 +78,9 @@ const {
 const DATA_URL = null
 const PRINTFUL_URL = 'https://api.printful.com'
 
-const DSHOP_CACHE = IS_TEST
-  ? TEST_DSHOP_CACHE
-  : process.env.DSHOP_CACHE || `${__dirname}/../data`
+const DSHOP_CACHE = path.resolve(
+  IS_TEST ? TEST_DSHOP_CACHE : process.env.DSHOP_CACHE || `${__dirname}/../data`
+)
 
 const THEMES_CACHE = IS_TEST
   ? TEST_THEMES_CACHE

--- a/backend/utils/hostCache.js
+++ b/backend/utils/hostCache.js
@@ -1,0 +1,57 @@
+/**
+ * Singleton to keep track of hostname->auth_token for speedy lookups for static
+ * assets.
+ */
+
+const { ShopDomain } = require('../models')
+const { getLogger } = require('../utils/logger')
+
+const log = getLogger('utils.hostCache')
+let lastLookupCleanup = 0
+let lastLookup = {}
+const hostnames = {}
+
+const LOOKUP_LIMIT = 3000 // 3 seconds
+const LOOKUP_CLEANUP_INTERVAL = 900000 // 15 minutes
+
+/**
+ * Resolve a hostname to a shop's auth_token
+ *
+ * @param host {string} Value from a Host header
+ * @returns {string} auth_token if found
+ */
+async function hostCache(host) {
+  if (!host) return
+
+  const now = +new Date()
+
+  // Do not infinitely grow lookup
+  if (now - lastLookupCleanup > LOOKUP_CLEANUP_INTERVAL) {
+    lastLookup = {}
+    lastLookupCleanup = now
+  }
+
+  if (typeof hostnames[host] === 'undefined') {
+    log.debug('Cache miss')
+
+    // We don't want to poke the DB too often for static file requests
+    if (!lastLookup[host] || now - lastLookup[host] > LOOKUP_LIMIT) {
+      const shopDom = await ShopDomain.findOne({
+        where: { domain: host },
+        include: 'shop'
+      })
+
+      if (shopDom) {
+        hostnames[host] = shopDom.shop.authToken
+      }
+
+      lastLookup[host] = now
+    }
+  } else {
+    log.debug('Cache hit')
+  }
+
+  return hostnames[host]
+}
+
+module.exports = hostCache


### PR DESCRIPTION
This PR allows us to serve assembled shops from the backend by pointing a known domain at the backend.

This will require some modifications to the nginx ingress to set the `X-Forwarded-Host` header for prod deployments.

Will follow this up later with an update to DNS instructions stuff but want to get in some testing before that happens.