### PR TITLE
DNS instructions to use backend address

### DIFF
--- a/backend/utils/const.js
+++ b/backend/utils/const.js
@@ -67,7 +67,8 @@ const {
   REDIS_URL,
   IPFS_GATEWAY, // IPFS gateway override
   BUCKET_PREFIX = DEFAULT_BUCKET_PREFIX,
-  SERVICE_PREFIX = DEFAULT_SERVICE_PREFIX
+  SERVICE_PREFIX = DEFAULT_SERVICE_PREFIX,
+  EXTERNAL_IP
 } = process.env
 
 /**
@@ -77,6 +78,9 @@ const {
  */
 const DATA_URL = null
 const PRINTFUL_URL = 'https://api.printful.com'
+
+// Service that returns a plaintext IP for a GET request
+const EXTERNAL_IP_SERVICE_URL = 'https://api.ipify.org'
 
 const DSHOP_CACHE = path.resolve(
   IS_TEST ? TEST_DSHOP_CACHE : process.env.DSHOP_CACHE || `${__dirname}/../data`
@@ -111,5 +115,7 @@ module.exports = {
   PINATA_API,
   PINATA_GATEWAY,
   BUCKET_PREFIX,
-  SERVICE_PREFIX
+  SERVICE_PREFIX,
+  EXTERNAL_IP,
+  EXTERNAL_IP_SERVICE_URL
 }

--- a/backend/utils/ip.js
+++ b/backend/utils/ip.js
@@ -1,0 +1,43 @@
+/**
+ * IP address utilities
+ */
+const fetch = require('node-fetch')
+const { getLogger } = require('./logger')
+const { IS_DEV, EXTERNAL_IP, EXTERNAL_IP_SERVICE_URL } = require('./const')
+
+const log = getLogger('utils.ip')
+
+/**
+ * Return our external IP address
+ *
+ * @returns {string} IP address
+ */
+async function getMyIP() {
+  if (typeof EXTERNAL_IP !== 'undefined') {
+    log.debug(`Using preconfigured IP address for shop host (${EXTERNAL_IP})`)
+    return EXTERNAL_IP
+  }
+
+  if (IS_DEV) {
+    log.debug('Using local IP (127.0.0.1)')
+    return '127.0.0.1'
+  }
+
+  log.debug('Figuring out external IP address for system...')
+
+  return await resolveIP()
+}
+
+/**
+ * Resolve our external IP using an external service
+ *
+ * @returns {string} IP address
+ */
+async function resolveIP() {
+  const res = await fetch(EXTERNAL_IP_SERVICE_URL)
+  return await res.text()
+}
+
+module.exports = {
+  getMyIP
+}

--- a/backend/utils/ip.js
+++ b/backend/utils/ip.js
@@ -2,6 +2,7 @@
  * IP address utilities
  */
 const fetch = require('node-fetch')
+const memoize = require('lodash/memoize')
 const { getLogger } = require('./logger')
 const { IS_DEV, EXTERNAL_IP, EXTERNAL_IP_SERVICE_URL } = require('./const')
 
@@ -12,7 +13,7 @@ const log = getLogger('utils.ip')
  *
  * @returns {string} IP address
  */
-async function getMyIP() {
+async function _getMyIP() {
   if (typeof EXTERNAL_IP !== 'undefined') {
     log.debug(`Using preconfigured IP address for shop host (${EXTERNAL_IP})`)
     return EXTERNAL_IP
@@ -39,5 +40,5 @@ async function resolveIP() {
 }
 
 module.exports = {
-  getMyIP
+  getMyIP: memoize(_getMyIP)
 }


### PR DESCRIPTION
Changes DNS instructions so that instead of pointing to the IPFS gateway assuming it has AutoSSL configured, to use:

- If CNAME: the hostname from `networkConfig.backendUrl`
- if A: `EXTERNAL_IP` if configured, or the external IP as seen by an ipify request, or 127.0.0.1 if localhost

Depends on: https://github.com/OriginProtocol/origin/pull/4510