### PR TITLE
feat: Auto-select first payment option in checkout

### DIFF
--- a/shop/src/pages/checkout/ChoosePayment.js
+++ b/shop/src/pages/checkout/ChoosePayment.js
@@ -116,7 +116,7 @@ const ChoosePayment = () => {
   )
 
   useEffect(() => {
-    if (paymentMethods.length === 1 || paymentMethod == undefined) {
+    if (paymentMethods.length === 1 || paymentMethod === undefined) {
       dispatch({ type: 'updatePaymentMethod', method: paymentMethods[0] })
     }
   }, [paymentMethods.length, paymentMethod])

--- a/shop/src/pages/checkout/ChoosePayment.js
+++ b/shop/src/pages/checkout/ChoosePayment.js
@@ -116,10 +116,10 @@ const ChoosePayment = () => {
   )
 
   useEffect(() => {
-    if (paymentMethods.length === 1) {
+    if (paymentMethods.length === 1 || paymentMethod == undefined) {
       dispatch({ type: 'updatePaymentMethod', method: paymentMethods[0] })
     }
-  }, [paymentMethods.length])
+  }, [paymentMethods.length, paymentMethod])
 
   const isOfflinePayment = !!get(cart, 'paymentMethod.instructions', false)
 

--- a/shop/src/pages/checkout/ChoosePayment.js
+++ b/shop/src/pages/checkout/ChoosePayment.js
@@ -116,7 +116,9 @@ const ChoosePayment = () => {
   )
 
   useEffect(() => {
-    if (paymentMethods.length === 1 || paymentMethod === undefined) {
+    const shouldSelectFirstOptions =
+      paymentMethods.length >= 1 && paymentMethod === undefined
+    if (shouldSelectFirstOptions) {
       dispatch({ type: 'updatePaymentMethod', method: paymentMethods[0] })
     }
   }, [paymentMethods.length, paymentMethod])


### PR DESCRIPTION
Add functionality to select the first payment option whenever the payment component mounts and the end-user has not made a selection on their own. Ensuring that once an end-user has picked an option that is the option that is selected should the end-user exit the _Payment_ page, and then return.

## Screenshots

![Screen Recording 2020-11-12 at 21 07 28](https://user-images.githubusercontent.com/844516/99027865-83ccf180-252b-11eb-886a-f82352dbe317.gif)


Resolves: https://github.com/OriginProtocol/dshop/issues/502