### PR TITLE
Wait out rate limit

### DIFF
--- a/backend/scripts/printful/downloadProductData.js
+++ b/backend/scripts/printful/downloadProductData.js
@@ -51,8 +51,14 @@ async function downloadProductData({
     )
   }
 
+  let index = 1
   for (const id of ids) {
     await getProduct({ PrintfulURL, apiAuth, OutputDir, id })
+    if (index % 75 === 0) {
+      // Wait out rate limit
+      await new Promise((r) => setTimeout(r, 60000))
+    }
+    index++
   }
 
   return ids


### PR DESCRIPTION
Printful seems to have [rate-limit](https://www.printful.com/docs) of 120 reqs/minute. This is causing failures during sync in some of the stores. This adds a sleep of 60s after every 75th request while getting data from printful API. 