### PR TITLE
Make printful syncing async

### DIFF
--- a/backend/db/migrations/20201201125225-addPrintfulSyncing.js
+++ b/backend/db/migrations/20201201125225-addPrintfulSyncing.js
@@ -1,0 +1,12 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('shops', 'printful_syncing', { 
+      type: Sequelize.BOOLEAN
+    })
+  },
+  down: (queryInterface) => {
+    return queryInterface.removeColumn('shops', 'printful_syncing')
+  }
+}

--- a/backend/logic/printful/sync/downloadPrintfulMockups.js
+++ b/backend/logic/printful/sync/downloadPrintfulMockups.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const sharp = require('sharp')
 const https = require('https')
-const { getLogger } = require('../../utils/logger')
+const { getLogger } = require('../../../utils/logger')
 
 const log = getLogger('scripts.printful.downloadPrintfulMockups')
 

--- a/backend/logic/printful/sync/resizePrintfulMockups.js
+++ b/backend/logic/printful/sync/resizePrintfulMockups.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const sharp = require('sharp')
 const uniq = require('lodash/uniq')
 
-const { getLogger } = require('../../utils/logger')
+const { getLogger } = require('../../../utils/logger')
 
 const log = getLogger('utils.printfu.resizePrintfulMockups')
 

--- a/backend/logic/printful/sync/writeProductData.js
+++ b/backend/logic/printful/sync/writeProductData.js
@@ -3,7 +3,7 @@ const sortBy = require('lodash/sortBy')
 const get = require('lodash/get')
 const kebabCase = require('lodash/kebabCase')
 
-const { getLogger } = require('../../utils/logger')
+const { getLogger } = require('../../../utils/logger')
 
 const log = getLogger('utils.printful.writeProductData')
 

--- a/backend/models/shop.js
+++ b/backend/models/shop.js
@@ -27,6 +27,8 @@ module.exports = (sequelize, DataTypes) => {
       lastBlock: DataTypes.INTEGER,
       // True if the shop has changes that requires to get published.
       hasChanges: DataTypes.BOOLEAN,
+      // True if printful sync is in progress
+      printfulSyncing: DataTypes.BOOLEAN,
       enableCdn: {
         type: DataTypes.BOOLEAN,
         defaultValue: false

--- a/backend/queues/fallbackQueue.js
+++ b/backend/queues/fallbackQueue.js
@@ -38,7 +38,13 @@ class FallbackQueue {
       log: log.info,
       queue: this
     }
+    if (this.eventHandlers.active) {
+      this.eventHandlers.active(job)
+    }
     await this.processor(job)
+    if (this.eventHandlers.completed) {
+      this.eventHandlers.completed(job)
+    }
     return job
   }
 

--- a/backend/queues/printfulSyncProcessor.js
+++ b/backend/queues/printfulSyncProcessor.js
@@ -1,9 +1,9 @@
 const queues = require('./queues')
 
-const downloadProductData = require('../scripts/printful/downloadProductData')
-const writeProductData = require('../scripts/printful/writeProductData')
-const downloadPrintfulMockups = require('../scripts/printful/downloadPrintfulMockups')
-const resizePrintfulMockups = require('../scripts/printful/resizePrintfulMockups')
+const downloadProductData = require('../logic/printful/sync/downloadProductData')
+const writeProductData = require('../logic/printful/sync/writeProductData')
+const downloadPrintfulMockups = require('../logic/printful/sync/downloadPrintfulMockups')
+const resizePrintfulMockups = require('../logic/printful/sync/resizePrintfulMockups')
 
 const { Shop } = require('../models')
 
@@ -11,6 +11,33 @@ const attachToQueue = () => {
   const queue = queues['printfulSyncQueue']
   queue.process(processor)
   queue.resume() // Start if paused
+
+  const updateSyncStatus = async (job, status, hasChanges) => {
+    if (!job.data) return
+
+    const { shopId } = job.data
+
+    if (!shopId) return
+
+    await Shop.update(
+      { printfulSyncing: status, hasChanges },
+      { where: { id: shopId } }
+    )
+  }
+
+  queue.on('completed', (job) => {
+    updateSyncStatus(job, false, false)
+  })
+  queue.on('failed', (job) => {
+    updateSyncStatus(job, false)
+  })
+
+  queue.on('waiting', (job) => {
+    updateSyncStatus(job, true)
+  })
+  queue.on('active', (job) => {
+    updateSyncStatus(job, true)
+  })
 }
 
 const processor = async (job) => {
@@ -24,13 +51,13 @@ const processor = async (job) => {
   const {
     OutputDir,
     apiKey,
-    shopId,
     smartFetch,
     forceRefetchIds,
     refreshImages
   } = job.data
 
   let taskStartTime = Date.now()
+
   const updatedIds = await downloadProductData({
     OutputDir,
     printfulApi: apiKey,
@@ -61,13 +88,6 @@ const processor = async (job) => {
 
   await resizePrintfulMockups({ OutputDir, force: refreshImages })
   log(90, `Resize mockups, Time Taken: ${(Date.now() - taskStartTime) / 1000}s`)
-
-  if (shopId) {
-    const shop = await Shop.findOne({ where: { id: shopId } })
-    shop.update({
-      hasChanges: true
-    })
-  }
 
   log(
     100,

--- a/backend/queues/printfulSyncProcessor.js
+++ b/backend/queues/printfulSyncProcessor.js
@@ -19,10 +19,13 @@ const attachToQueue = () => {
 
     if (!shopId) return
 
-    await Shop.update(
-      { printfulSyncing: status, hasChanges },
-      { where: { id: shopId } }
-    )
+    const data = { printfulSyncing: status }
+
+    if (hasChanges !== undefined) {
+      data.hasChanges = hasChanges
+    }
+
+    await Shop.update(data, { where: { id: shopId } })
   }
 
   queue.on('completed', (job) => {

--- a/backend/queues/printfulSyncProcessor.js
+++ b/backend/queues/printfulSyncProcessor.js
@@ -26,7 +26,7 @@ const attachToQueue = () => {
   }
 
   queue.on('completed', (job) => {
-    updateSyncStatus(job, false, false)
+    updateSyncStatus(job, false, true)
   })
   queue.on('failed', (job) => {
     updateSyncStatus(job, false)

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -347,7 +347,8 @@ module.exports = function (router) {
             'hostname',
             'hasChanges',
             'listingId',
-            'walletAddress'
+            'walletAddress',
+            'printfulSyncing'
           ])
         }
       })

--- a/backend/routes/shops.js
+++ b/backend/routes/shops.js
@@ -35,7 +35,7 @@ const { isPublicDNSName } = require('../utils/dns')
 const { getLogger } = require('../utils/logger')
 const { readProductsFile } = require('../logic/products')
 const { queues } = require('../queues')
-const printfulSyncProcessor = require('../queues/printfulSyncProcessor')
+const { printfulSyncQueue } = require('../queues/queues')
 const { updateShopConfig } = require('../logic/shop/config')
 const { createShop } = require('../logic/shop/create')
 const sellerContactEmail = require('../utils/emails/sellerContact')
@@ -167,17 +167,15 @@ module.exports = function (router) {
       }
 
       const OutputDir = `${DSHOP_CACHE}/${req.shop.authToken}`
-
-      await printfulSyncProcessor.processor({
-        data: {
+      await printfulSyncQueue.add(
+        {
           OutputDir,
           apiKey: printful,
           shopId: req.shop.id,
           refreshImages: req.body.refreshImages ? true : false
         },
-        log: (data) => log.debug(data),
-        progress: () => {}
-      })
+        { attempts: 1 }
+      )
 
       res.json({ success: true })
     }

--- a/shop/src/data/state.js
+++ b/shop/src/data/state.js
@@ -279,12 +279,6 @@ const reducer = (state, action) => {
     if (['products', 'collections'].indexOf(action.target)) {
       newState = set(newState, 'hasChanges', true)
     }
-  } else if (action.type === 'hasChanges') {
-    newState = set(
-      newState,
-      'hasChanges',
-      action.value === false ? false : true
-    )
   } else if (action.type === 'setAdminLocation') {
     newState = set(newState, 'adminLocation', action.location)
   } else if (action.type === 'setStorefrontLocation') {

--- a/shop/src/pages/admin/settings/apps/PrintfulSync.js
+++ b/shop/src/pages/admin/settings/apps/PrintfulSync.js
@@ -22,7 +22,7 @@ const AdminPrintfulSync = ({ buttonText, buttonClass, className = '' }) => {
   useEffect(() => {
     let interval, done
 
-    // Polls shopConfig every 5 seconds to see if 
+    // Polls shopConfig every 5 seconds to see if
     // syncing has completed
 
     if (printfulSyncing) {
@@ -74,7 +74,10 @@ const AdminPrintfulSync = ({ buttonText, buttonClass, className = '' }) => {
         'Are you sure you want to sync with Printful?',
         'admin.settings.apps.printful.confirmSync'
       )}
-      confirmedText={fbt('Your products are being synced. It usually takes a few minutes before it is complete.', 'admin.settings.apps.printful.synced')}
+      confirmedText={fbt(
+        'Your products are being synced. It usually takes a few minutes before it is complete.',
+        'admin.settings.apps.printful.synced'
+      )}
       loadingText={`${fbt('Syncing', 'Syncing')}...`}
       onConfirm={() =>
         post(`/shop/sync-printful`, {


### PR DESCRIPTION
Related to #796 

Pushes printful manual sync requests to the queue and keeps track of the status through a DB column. The status is long-polled with a 5s duration on the frontend.