### PR TITLE
Clear token state when changing selection in `useToken` hook

### DIFF
--- a/shop/src/utils/useToken.js
+++ b/shop/src/utils/useToken.js
@@ -57,7 +57,8 @@ function useToken(activeToken = {}, totalUsd) {
             hasBalance,
             hasAllowance: true,
             loading: false,
-            error: null
+            error: null,
+            contract: null
           })
         } else if (activeToken.address) {
           const contract = new ethers.Contract(


### PR DESCRIPTION
Fixes #818.

It happened only when switching from other tokens to ETH. Since the `setState` uses a reducer, the `contract` key was never really overwritten even when selecting ETH.