### PR TITLE
Surface Printful auto-fulfillment failures in the admin UI

### DIFF
--- a/backend/logic/printful/index.js
+++ b/backend/logic/printful/index.js
@@ -242,14 +242,15 @@ const autoFulfillOrder = async (orderObj, shopConfig, shop) => {
 
     try {
       // Notify the merchant of the fulfillment failure by email.
-      const message = error.message
-      await sendPrintfulOrderFailedEmail(shop.id, orderObj, { message })
+      const reason = error.message
+      await sendPrintfulOrderFailedEmail(shop.id, orderObj, { reason })
 
       // Store the fulfillment error in the order's metadata.
+      const message = 'Auto-fulfillment error: ' + reason
       const errorData = {
         // Add a new fullfillError field.
-        fulfillError: message,
-        // Add to the possibly already existing error field which stores the list of errors.
+        autoFulfillError: message,
+        // Add the error to the list of errors.
         error: [...get(orderObj, 'data.error', []), message]
       }
       const data = { ...orderObj.data, ...errorData }

--- a/backend/logic/printful/index.js
+++ b/backend/logic/printful/index.js
@@ -89,7 +89,7 @@ const placeOrder = async (apiKey, orderData, opts = {}) => {
   } catch (e) {
     log.error('Error parsing Printful response')
     log.error(text)
-    return { success: false }
+    return { success: false, message: 'Error parsing Printful API response' }
   }
 }
 
@@ -235,19 +235,30 @@ const fetchTaxRates = async (apiKey, data) => {
  * @returns {Promise<void>}
  */
 const autoFulfillOrder = async (orderObj, shopConfig, shop) => {
-  const sendFailureEmail = async (message) => {
-    try {
-      const data = {
-        message: message || 'An unknown error occured'
-      }
+  const shopId = shop.id
 
-      await sendPrintfulOrderFailedEmail(shop.id, orderObj, data)
+  const handleError = async (error) => {
+    log.error(`Shop ${shopId} - Failed to auto-fulfill order`, error)
+
+    try {
+      // Notify the merchant of the fulfillment failure by email.
+      const message = error.message
+      await sendPrintfulOrderFailedEmail(shop.id, orderObj, { message })
+
+      // Store the fulfillment error in the order's metadata.
+      const errorData = {
+        // Add a new fullfillError field.
+        fulfillError: message,
+        // Add to the possibly already existing error field which stores the list of errors.
+        error: [...get(orderObj, 'data.error', []), message]
+      }
+      const data = { ...orderObj.data, ...errorData }
+      await orderObj.update({ data })
     } catch (err) {
-      log.error('Failed to send email', err)
+      log.error('autoFulfillOrder error handler failure', err)
     }
   }
 
-  const shopId = shop.id
   try {
     log.info(
       `Shop ${shopId} - Trying to auto fulfill order ${orderObj.id} on printful...`
@@ -255,7 +266,7 @@ const autoFulfillOrder = async (orderObj, shopConfig, shop) => {
 
     const apiKey = shopConfig.printful
     if (!apiKey) {
-      return
+      return handleError(new Error('Missing Printful API key'))
     }
 
     // TODO: Should this be a configurable variable on admin?
@@ -274,14 +285,12 @@ const autoFulfillOrder = async (orderObj, shopConfig, shop) => {
     })
 
     if (!success) {
-      log.error(`Shop ${shopId} - Failed to auto-fulfill order`, message)
-      await sendFailureEmail(message)
-    } else {
-      log.info(`Shop ${shopId} - Order created on printful`)
+      return handleError(new Error(message))
     }
+
+    log.info(`Shop ${shopId} - Order created on printful`)
   } catch (err) {
-    log.error(`Shop ${shopId} - Failed to auto-fulfill order`, err)
-    await sendFailureEmail()
+    return handleError(err)
   }
 }
 

--- a/backend/test/printful.test.js
+++ b/backend/test/printful.test.js
@@ -86,10 +86,11 @@ describe('Printful', () => {
 
     // Since the shop does not have a printful API key we expect a fulfillment error.
     await order.reload()
-    expect(order.data.fulfillError).to.be.a('string')
-    expect(order.data.fulfillError).to.equal('Missing Printful API key')
+    const expectedError = 'Auto-fulfillment error: Missing Printful API key'
+    expect(order.data.autoFulfillError).to.be.a('string')
+    expect(order.data.autoFulfillError).to.equal(expectedError)
     expect(order.data.error).to.be.an('array')
     expect(order.data.error.length).to.equal(1)
-    expect(order.data.error[0]).to.equal('Missing Printful API key')
+    expect(order.data.error[0]).to.equal(expectedError)
   })
 })

--- a/backend/test/printful.test.js
+++ b/backend/test/printful.test.js
@@ -6,13 +6,12 @@ const {
   getTestWallet,
   createTestShop,
   getOrCreateTestNetwork,
-  generatePgpKey,
+  generatePgpKey
 } = require('./utils')
 const { Order, Product } = require('../models')
 const encConf = require('../utils/encryptedConfig')
 const { OrderPaymentStatuses, OrderPaymentTypes } = require('../utils/enums')
 const { autoFulfillOrder } = require('../logic/printful')
-
 
 describe('Printful', () => {
   let network, shop, shopConfig
@@ -93,5 +92,4 @@ describe('Printful', () => {
     expect(order.data.error.length).to.equal(1)
     expect(order.data.error[0]).to.equal('Missing Printful API key')
   })
-
 })

--- a/backend/test/printful.test.js
+++ b/backend/test/printful.test.js
@@ -1,0 +1,97 @@
+const chai = require('chai')
+chai.use(require('chai-string'))
+const expect = chai.expect
+
+const {
+  getTestWallet,
+  createTestShop,
+  getOrCreateTestNetwork,
+  generatePgpKey,
+} = require('./utils')
+const { Order, Product } = require('../models')
+const encConf = require('../utils/encryptedConfig')
+const { OrderPaymentStatuses, OrderPaymentTypes } = require('../utils/enums')
+const { autoFulfillOrder } = require('../logic/printful')
+
+
+describe('Printful', () => {
+  let network, shop, shopConfig
+
+  before(async () => {
+    // Note: Enable the marketplace contract initially.
+    // Then later in this test suite it gets disabled.
+    network = await getOrCreateTestNetwork({ useMarketplace: true })
+
+    // Use account 1 as the merchant's.
+    const sellerWallet = getTestWallet(1)
+    const sellerPk = sellerWallet.privateKey
+
+    // Create the merchant's PGP key.
+    const pgpPrivateKeyPass = 'password123'
+    const key = await generatePgpKey('tester', pgpPrivateKeyPass)
+    const pgpPublicKey = key.publicKeyArmored
+    const pgpPrivateKey = key.privateKeyArmored
+
+    shop = await createTestShop({
+      network,
+      sellerPk,
+      pgpPrivateKeyPass,
+      pgpPublicKey,
+      pgpPrivateKey,
+      inventory: true
+    })
+
+    shopConfig = encConf.getConfig(shop.config)
+  })
+
+  it('should add a fulfillment error to the order metadata', async () => {
+    const productId = 'product_' + Date.now()
+    await Product.create({
+      shopId: shop.id,
+      productId,
+      stockLeft: 4,
+      variantsStock: {
+        0: 1,
+        1: 3
+      }
+    })
+
+    const orderData = {
+      shopId: shop.id,
+      networkId: network.id,
+      paymentType: OrderPaymentTypes.Offline,
+      paymentStatus: OrderPaymentStatuses.Pending,
+      paymentCode: `customId-${Date.now()}`,
+      shortId: 'testorderid',
+      data: {
+        items: [
+          {
+            product: productId,
+            quantity: 1,
+            price: 2500,
+            variant: 0
+          },
+          {
+            product: productId,
+            quantity: 2,
+            price: 2500,
+            variant: 1
+          }
+        ]
+      }
+    }
+
+    const order = await Order.create(orderData)
+
+    await autoFulfillOrder(order, shopConfig, shop)
+
+    // Since the shop does not have a printful API key we expect a fulfillment error.
+    await order.reload()
+    expect(order.data.fulfillError).to.be.a('string')
+    expect(order.data.fulfillError).to.equal('Missing Printful API key')
+    expect(order.data.error).to.be.an('array')
+    expect(order.data.error.length).to.equal(1)
+    expect(order.data.error[0]).to.equal('Missing Printful API key')
+  })
+
+})

--- a/backend/test/utils.js
+++ b/backend/test/utils.js
@@ -185,6 +185,7 @@ async function getOrCreateTestNetwork(opts = {}) {
       gcpCredentials: 'gcpCredentials',
       domain: 'domain.com',
       deployDir: 'deployDir',
+      fallbackShopConfig: {},
       ...opts.configOverride
     })
   }


### PR DESCRIPTION
Currently in case of a Printful auto-fulfillment error, the merchant receives an email.
But in the admin UI, the orders page and order details page do not show any obvious warning that something went wrong and needs the merchant's attention.

This change stores any auto-fulfillment error in the order's metadata in the DB. That will cause the UI to display a red flag next to the order on the orders page and an error message on the order details page.

Note: as a future improvement, we could discard this error if the merchant submits the order manually via the order details page.
