### PR TITLE
Skip discord notifications for autossl failures

### DIFF
--- a/backend/queues/index.js
+++ b/backend/queues/index.js
@@ -4,7 +4,7 @@ const get = require('lodash/get')
 
 // List of queues and shops for which we don't post failures in discord for.
 const discordBlacklistQueues = ['autossl']
-const discordBlacklistShopIds = [ 1 ] // Gitcoin (shopId=1) is deleted.
+const discordBlacklistShopIds = [1] // Gitcoin (shopId=1) is deleted.
 
 /**
  * Attaches all backend queue processing functions to their respective queues.
@@ -22,7 +22,10 @@ function runProcessors() {
   const failureCallback = (job, error) => {
     const queueName = job.queue.name
     const shopId = get(job, 'data.shopId', -1)
-    if (discordBlacklistQueues.includes(queueName) || discordBlacklistShopIds.includes(Number(shopId))) {
+    if (
+      discordBlacklistQueues.includes(queueName) ||
+      discordBlacklistShopIds.includes(Number(shopId))
+    ) {
       return
     }
 

--- a/backend/queues/index.js
+++ b/backend/queues/index.js
@@ -1,13 +1,44 @@
+const { Sentry } = require('../sentry')
 const discordWebhook = require('../utils/discordWebhook')
 const queues = require('./queues')
 const get = require('lodash/get')
 
-// List of queues and shops for which we don't post failures in discord for.
-const discordBlacklistQueues = ['autossl']
-const discordBlacklistShopIds = [1] // Gitcoin (shopId=1) is deleted.
+// Queues for which we log errors in Sentry.
+const sentryWhitelistedQueues = ['events', 'makeOffer', 'printfulSync', 'tx']
+
+// Queues and shops for which we don't post failures in discord.
+const discordBlacklistedQueues = ['autossl']
+const discordBlacklistedShopIds = [1] // Gitcoin (shopId=1) is deleted.
+
+/**
+ * Queue failure callback function.
+ */
+function failureCallback(job, error) {
+  const queueName = job.queue.name
+  const shopId = get(job, 'data.shopId', -1)
+
+  if (sentryWhitelistedQueues.includes(queueName)) {
+    Sentry.captureException(error)
+  }
+
+  if (
+    discordBlacklistedQueues.includes(queueName) ||
+    discordBlacklistedShopIds.includes(Number(shopId))
+  ) {
+    discordWebhook.postQueueError({
+      queueName,
+      errorMessage: error.message,
+      jobId: job.id,
+      shopId,
+      attempts: job.attemptsMade,
+      stackTrace: error.stack
+    })
+  }
+}
 
 /**
  * Attaches all backend queue processing functions to their respective queues.
+ * Registers up a failure callback.
  */
 function runProcessors() {
   require('./makeOfferProcessor').attachToQueue()
@@ -19,26 +50,7 @@ function runProcessors() {
   require('./deploymentProcessor').attachToQueue()
   require('./dnsStatusProcessor').attachToQueue()
 
-  const failureCallback = (job, error) => {
-    const queueName = job.queue.name
-    const shopId = get(job, 'data.shopId', -1)
-    if (
-      discordBlacklistQueues.includes(queueName) ||
-      discordBlacklistShopIds.includes(Number(shopId))
-    ) {
-      return
-    }
-
-    discordWebhook.postQueueError({
-      queueName,
-      errorMessage: error.message,
-      jobId: job.id,
-      shopId,
-      attempts: job.attemptsMade,
-      stackTrace: error.stack
-    })
-  }
-
+  // Registers the failure callback
   for (const queueName in queues) {
     queues[queueName].on('failed', failureCallback)
   }

--- a/backend/queues/index.js
+++ b/backend/queues/index.js
@@ -33,7 +33,7 @@ function runProcessors() {
       queueName,
       errorMessage: error.message,
       jobId: job.id,
-      shopId: get(job, 'data.shopId', ''),
+      shopId,
       attempts: job.attemptsMade,
       stackTrace: error.stack
     })

--- a/backend/queues/queues.js
+++ b/backend/queues/queues.js
@@ -6,7 +6,6 @@
  *
  * Example REDIS_URL=redis://0.0.0.0:6379
  */
-const { Sentry } = require('../sentry')
 const { REDIS_URL } = require('../utils/const')
 const { getLogger } = require('../utils/logger')
 
@@ -14,9 +13,6 @@ const Queue = REDIS_URL ? require('bull') : require('./fallbackQueue')
 const backendUrl = REDIS_URL ? REDIS_URL : undefined
 const queueOpts = {}
 const log = getLogger('queues.queues')
-
-// Capture in Sentry the failure of any job from these queues.
-const CAPTURE_FAILED_QUEUES = ['autossl', 'etl', 'tx']
 
 if (REDIS_URL) {
   log.info(`Queue init: Using Redis at ${REDIS_URL}`)
@@ -104,15 +100,6 @@ const all = [
     })
   )
 ]
-
-all.forEach((q) => {
-  if (CAPTURE_FAILED_QUEUES.includes(q.name)) {
-    q.on('failed', function (job, err) {
-      Sentry.captureException(err)
-      log.error(`Job ${job.id} failed with error: ${err.toString()}`)
-    })
-  }
-})
 
 module.exports = {}
 for (const queue of all) {


### PR DESCRIPTION
Fix #872 

- Disable discord notifications on autossl failures. Some failures are expected and the noise/signal ratio was bad.
- Disable all discord notification for gitcoin - that shop is no longer alive.
- Enable sentry logging on business critical queues
