### PR TITLE
Add retries to the tx queue

### DIFF
--- a/backend/queues/queues.js
+++ b/backend/queues/queues.js
@@ -21,13 +21,18 @@ if (REDIS_URL) {
 }
 
 const all = [
-  new Queue(
-    'makeOffer',
-    backendUrl,
-    Object.assign(queueOpts, {
-      prefix: '{makeOffer}'
-    })
-  ),
+  new Queue('makeOffer', backendUrl, {
+    prefix: '{makeOffer}',
+    defaultJobOptions: {
+      // Up to 6 attempts to process the job, using an exponential backoff
+      // having a 60 sec initial delay.
+      attempts: 6,
+      backoff: {
+        type: 'exponential',
+        delay: 60000
+      }
+    }
+  }),
   new Queue(
     'download',
     backendUrl,
@@ -78,13 +83,18 @@ const all = [
       prefix: '{etl}'
     })
   ),
-  new Queue(
-    'tx',
-    backendUrl,
-    Object.assign(queueOpts, {
-      prefix: '{tx}'
-    })
-  ),
+  new Queue('tx', backendUrl, {
+    prefix: '{tx}',
+    defaultJobOptions: {
+      // Up to 4 attempts to process the job, using an exponential backoff
+      // having a 15 sec initial delay.
+      attempts: 4,
+      backoff: {
+        type: 'exponential',
+        delay: 15000
+      }
+    }
+  }),
   new Queue(
     'dns',
     backendUrl,

--- a/backend/queues/txProcessor.js
+++ b/backend/queues/txProcessor.js
@@ -114,15 +114,7 @@ async function processor(job) {
     // Enqueue a job to record an offer on the marketplace contract.
     const makeOfferQueue = queues['makeOfferQueue']
     const jobData = { shopId, encryptedDataIpfsHash, paymentCode, paymentType }
-    const jobOpts = {
-      // Up to 6 attempts with exponential backoff with a 60sec initial delay.
-      attempts: 6,
-      backoff: {
-        type: 'exponential',
-        delay: 60000
-      }
-    }
-    await makeOfferQueue.add(jobData, jobOpts)
+    await makeOfferQueue.add(jobData)
 
     // Update the transaction in the DB.
     await transaction.update({

--- a/backend/routes/_makeOffer.js
+++ b/backend/routes/_makeOffer.js
@@ -9,24 +9,14 @@ async function makeOffer(req, res) {
   const encryptedDataIpfsHash = req.body.data
   const { shop, amount, paymentCode, paymentType, paymentStatus } = req
 
-  await makeOfferQueue.add(
-    {
-      shopId: shop.id,
-      amount,
-      encryptedDataIpfsHash,
-      paymentCode,
-      paymentType,
-      paymentStatus
-    },
-    {
-      // Up to 6 attempts with exponential backoff with a 60sec initial delay.
-      attempts: 6,
-      backoff: {
-        type: 'exponential',
-        delay: 60000
-      }
-    }
-  )
+  await makeOfferQueue.add({
+    shopId: shop.id,
+    amount,
+    encryptedDataIpfsHash,
+    paymentCode,
+    paymentType,
+    paymentStatus
+  })
 
   res.json({ success: true })
 }

--- a/shop/src/pages/admin/_Nav.js
+++ b/shop/src/pages/admin/_Nav.js
@@ -12,7 +12,7 @@ import PreviewBanner from 'components/PreviewBanner'
 import AccountSelector from './_AccountSelector'
 import User from './_User'
 import NewShop from './_NewShop'
-import LiveChat from './_LiveChat'
+//import LiveChat from './_LiveChat'
 
 const Nav = ({ newShop, setNewShop, only }) => {
   const [{ admin }] = useStateValue()

--- a/shop/src/pages/admin/onboarding/_Banner.js
+++ b/shop/src/pages/admin/onboarding/_Banner.js
@@ -19,8 +19,8 @@ const Banner = ({ totalTasks, completedTasks, shopDomain }) => {
    * ShareActions: Displays a 'Copy to Clipboard' button on the Banner. If the user clicks on the button, the store link is copied
    * to the clipboard, and the button turns into a checkmark to indicate success.
    * @prop clicked: <boolean> should be true if the user clicks the 'Copy to Clipboard' button
-   * 
-   * Button and Tooltip references: 
+   *
+   * Button and Tooltip references:
    *  https://getbootstrap.com/docs/5.0/components/buttons/
    *  https://getbootstrap.com/docs/5.0/components/tooltips/
    *

--- a/yarn.lock
+++ b/yarn.lock
@@ -25533,10 +25533,10 @@ webpack-subresource-integrity@^5.0.0-alpha.1:
   dependencies:
     typed-assert "^1.0.4"
 
-webpack@5.20.2:
-  version "5.20.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.20.2.tgz#55a6e461e2a6e1ca7467a419886acf9c7b052d5f"
-  integrity sha512-gGPip54KK7DznaaPHVuNGqym3LAXXL+bPkZ9SlLTCdHmmk+m5x+D4UZdhWvw32CMahYlZwZYPsioFIw36/txYQ==
+webpack@5.21.2:
+  version "5.21.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.21.2.tgz#647507e50d3637695be28af58a6a8246050394e7"
+  integrity sha512-xHflCenx+AM4uWKX71SWHhxml5aMXdy2tu/vdi4lClm7PADKxlyDAFFN1rEFzNV0MAoPpHtBeJnl/+K6F4QBPg==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.46"


### PR DESCRIPTION
Fix for #912 

The tx queue was not configured to be retry-able. If a tx hash failed lookup because it was too fresh to show up on Alchemy, the order would fail.

Added retries to the tx queue and also cleaned up the makeOffer queue so that retries are configure at init time rather than having to do it when posting every job.

Bull's reference doc: <https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md>