### PR TITLE
Fix shipping email failures

### DIFF
--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -14,6 +14,7 @@ const sendNewOrderEmail = require('../utils/emails/newOrder')
 
 const safeAttributes = [
   'shopId',
+  'shortId',
   'paymentStatus',
   'paymentType',
   'paymentCode',

--- a/backend/utils/emails/newOrder.js
+++ b/backend/utils/emails/newOrder.js
@@ -39,7 +39,9 @@ async function sendNewOrderEmail({
 }) {
   const { transporter, from, replyTo } = await getShopTransport(shop, network)
   if (!transporter) {
-    log.info(`No email transport configured. Skiped sending new order email.`)
+    log.info(
+      `Shop ${shop.id} - No email transport configured. Skipped sending new order email.`
+    )
     return
   }
 
@@ -191,10 +193,13 @@ async function sendNewOrderEmail({
   if (!skip) {
     transporter.sendMail(message, (err, msg) => {
       if (err) {
-        log.error(`Error sending buyer ${emailType} email:`, err)
+        log.error(
+          `Shop ${shop.id} - Error sending buyer ${emailType} email:`,
+          err
+        )
       } else {
         log.info(
-          `Buyer ${emailType} email sent, from ${message.from} to ${message.to}`
+          `Shop ${shop.id} - Buyer ${emailType} email sent, from ${message.from} to ${message.to}`
         )
         log.debug(msg.envelope)
       }
@@ -203,10 +208,13 @@ async function sendNewOrderEmail({
     if (!vars.skipVendorMail && messageVendor.to) {
       transporter.sendMail(messageVendor, (err, msg) => {
         if (err) {
-          log.error(`Error sending merchant ${emailType} email:`, err)
+          log.error(
+            `Shop ${shop.id} - Error sending merchant ${emailType} email:`,
+            err
+          )
         } else {
           log.info(
-            `Merchant ${emailType} email sent, from ${messageVendor.from} to ${messageVendor.to}`
+            `Shop ${shop.id} - Merchant ${emailType} email sent, from ${messageVendor.from} to ${messageVendor.to}`
           )
           log.debug(msg.envelope)
         }

--- a/packages/services/start.js
+++ b/packages/services/start.js
@@ -10,7 +10,10 @@ program
   )
   .option('-x, --ssl-proxy', 'Start SSL proxy')
   .option('-q, --quiet', 'Quiet')
+  .option('-s, --setup', 'Setup test: starts all services then stops them all')
   .parse(process.argv)
+
+const opts = program.opts()
 
 async function setup() {
   const stop = await start({
@@ -30,10 +33,10 @@ if (!process.argv.slice(2).length) {
   setup()
 } else {
   start({
-    ganache: program.ganache,
-    ipfs: program.ipfs,
-    deployContracts: program.deployContracts,
-    sslProxy: program.sslProxy,
-    quiet: program.quiet
+    ganache: opts.ganache,
+    ipfs: opts.ipfs,
+    deployContracts: opts.deployContracts,
+    sslProxy: opts.sslProxy,
+    quiet: opts.quiet
   })
 }

--- a/packages/utils/generatePrintfulOrder.js
+++ b/packages/utils/generatePrintfulOrder.js
@@ -1,13 +1,22 @@
 const get = require('lodash/get')
 const { Countries } = require('./Countries')
 
+/**
+ * Generates the data for calling the Printful API to place an order.
+ * For reference, see https://www.printful.com/docs/orders
+ *
+ * @param {models.Order||Object} DB order if called by the backend, or order data returned by the routes/orders/:orderId if called by the front-end.
+ * @param {Object} printfulIds: Data read from the shop's printful-ids.json file.
+ * @param {boolean} draft: If true, the order is created but not yet submitted for fullfilment and can still be edited.
+ * @returns {{}|{retail_costs: {total: string, shipping: string, subtotal: string, discount: string, currency: string, tax: string}, draft: *, recipient: {zip: *, country_code: *, phone: *, address2: *, city: *, state_name: *, address1: *, name: string, country_name: *, state_code: *}, external_id: *, items: *}}
+ */
 function generatePrintfulOrder(order, printfulIds, draft) {
   const data = order.data
   if (!data || !data.userInfo) return {}
 
   const printfulData = {
     draft,
-    external_id: order.orderId,
+    external_id: order.shortId,
     recipient: {
       name: `${data.userInfo.firstName} ${data.userInfo.lastName}`,
       phone: data.userInfo.phone,


### PR DESCRIPTION
The back-end was failing to send email due to this error firing:
https://github.com/OriginProtocol/dshop/blob/06275facb6bf17f50c5d11f8aa7aa9ca5808d868/backend/logic/printful/webhook.js#L183

This was caused by auto-fulfilled orders not having a correct external id set.

It is a bit confusing but both the dshop admin FE and the back-end can call the method generatePrintfulOrder.
In the case it was called by the backend, the field order.orderId did not exist.
Fixed by using order.shortId in both case and making sure shortId is present on orders returned to the front-end.

This should fix #874

Also improved the logging in the sendNewOrderEmail method to include the shopId in order to make future email failure related investigation for a given shop easier.