### PR TITLE
Handle primaryImage being null in ybm theme

### DIFF
--- a/shop/src/themes/ybm/components/About.js
+++ b/shop/src/themes/ybm/components/About.js
@@ -30,7 +30,7 @@ const About = () => {
         </div>
       </Header>
       <div className="sm:container sm:my-16 flex flex-col sm:flex-row">
-        {!primaryImage.url ? null : (
+        {!primaryImage || !primaryImage.url ? null : (
           <div className="flex-1 order-2 sm:order-1 bg-cover bg-no-repeat bg-center">
             <div
               style={{


### PR DESCRIPTION
Can't say I know why `primaryImage` might be null, but this appears to be the cause of the about page not rendering for some stores.

Closes #922