### PR TITLE
Devops materials for new cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,10 @@ node_modules/
 
 # Deployment #
 ##############
-secrets.yaml
-secrets-dev.yaml
-secrets-staging.yaml
-secrets-prod.yaml
+#secrets.yaml
+#secrets-dev.yaml
+#secrets-staging.yaml
+#secrets-prod.yaml
 secrets-*.env
 github.key
 
@@ -88,7 +88,7 @@ Thumbs.db
 
 # Secrets #
 devops/github
-devops/kubernetes/values/origin/secrets-*.enc.yaml
-devops/kubernetes/values/origin-monitoring/secrets
+*.dec
+*.dec.yaml
 
 dshop_setup

--- a/devops/cloudbuild.dshop0.yaml
+++ b/devops/cloudbuild.dshop0.yaml
@@ -15,14 +15,16 @@ steps:
 
   - id: 'Build docker image'
     name: 'gcr.io/cloud-builders/docker'
-    args: [
-      'build',
-      '-f ./devops/Dockerfile',
-      '-t "gcr.io/$PROJECT_ID/${_GCR_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)"',
-      '--build-arg SENTRY_DSN=${_SENTRY_DSN}',
-      '--build-arg ENVIRONMENT=${_ENVIRONMENT}',
-      '$(pwd)'
-    ]
+    entrypoint: '/bin/bash'
+    args:
+      - '-c'
+      - |
+      build \
+      -f ./devops/Dockerfile \
+      -t "gcr.io/$PROJECT_ID/${_GCR_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)" \
+      --build-arg SENTRY_DSN=${_SENTRY_DSN} \
+      --build-arg ENVIRONMENT=${_ENVIRONMENT} \
+      $(pwd)
 
   - id: 'Push the image to GCR'
     name: 'gcr.io/cloud-builders/docker'

--- a/devops/cloudbuild.dshop0.yaml
+++ b/devops/cloudbuild.dshop0.yaml
@@ -61,7 +61,7 @@ steps:
       - |
         yq -yi \
         .dshopImage.tag=$(cat .tag) \
-        values/dshop/${_ENVIRONMENT}.yaml
+        $(pwd)/devops/helm/values/dshop/${_ENVIRONMENT}.yaml
 
   # Ref: https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/helmfile
   - id: 'Update the Kubernetes Deployment'

--- a/devops/cloudbuild.dshop0.yaml
+++ b/devops/cloudbuild.dshop0.yaml
@@ -1,0 +1,79 @@
+---
+################################################################################
+# Cloudbuild file for Origin's dshop0 Kubernetes cluster.
+################################################################################
+substitutions:
+    _IMAGE_NAME: dshop-backend
+
+steps:
+  - id: 'Create unique build tag'
+    name: 'gcr.io/cloud-builders/docker'
+    entrypoint: '/bin/bash'
+    args:
+      - '-c'
+      - 'date +%Y%m%d%H%M%s > .tag'
+
+
+  - id: 'Build docker image'
+    name: 'gcr.io/cloud-builders/docker'
+    args: [
+      'build',
+      '-f ./devops/Dockerfile',
+      '-t "gcr.io/$PROJECT_ID/${_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)"',
+      '--build-arg SENTRY_DSN=${_SENTRY_DSN}',
+      '--build-arg ENVIRONMENT=${_ENVIRONMENT}',
+      '$(pwd)'
+    ]
+
+  - id: 'Push the image to GCR'
+    name: 'gcr.io/cloud-builders/docker'
+    entrypoint: '/bin/bash'
+    args:
+      - '-c'
+      - |
+        docker push \
+          gcr.io/$PROJECT_ID/${_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)
+
+  - id: 'Tag the image'
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: '/bin/bash'
+    args:
+      - '-c'
+      - |
+        gcloud container images add-tag \
+          "gcr.io/$PROJECT_ID/${_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)" \
+          "gcr.io/$PROJECT_ID/${_NAMESPACE}/${_IMAGE_NAME}:latest" \
+          --quiet
+
+        if [[ "$BRANCH_NAME" == "stable" ]]; then
+          gcloud container images add-tag \
+            "gcr.io/$PROJECT_ID/${_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)" \
+            "gcr.io/$PROJECT_ID/${_NAMESPACE}/${_IMAGE_NAME}:mainnet" \
+            --quiet
+        fi
+
+  - id: 'Set explicity version for this deployment'
+    name: "gcr.io/$PROJECT_ID/yq"
+    args: [
+      'yq',
+      '-yi',
+      '.dshopImage.tag=$(cat .tag)',
+      'values/dshop/${_ENVIRONMENT}.yaml'
+    ]
+
+  # Ref: https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/helmfile
+  - id: 'Update the Kubernetes Deployment'
+    name: "gcr.io/$PROJECT_ID/helmfile"
+    env:
+      - 'CLOUDSDK_COMPUTE_ZONE=us-west1-a'
+      - 'CLOUDSDK_CONTAINER_CLUSTER=dshop0'
+    args:
+      [
+        "--environment",
+        "${_ENVIRONMENT}",
+        "sync",
+      ]
+
+timeout: '3600s'
+options:
+  machineType: 'N1_HIGHCPU_32'

--- a/devops/cloudbuild.dshop0.yaml
+++ b/devops/cloudbuild.dshop0.yaml
@@ -19,7 +19,7 @@ steps:
     args:
       - '-c'
       - |
-        build \
+        docker build \
           -f ./devops/Dockerfile \
           -t "gcr.io/$PROJECT_ID/${_GCR_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)" \
           --build-arg SENTRY_DSN=${_SENTRY_DSN} \

--- a/devops/cloudbuild.dshop0.yaml
+++ b/devops/cloudbuild.dshop0.yaml
@@ -60,13 +60,12 @@ steps:
       - '-c'
       - |
         yq -yi \
-        .dshopImage.tag=$(cat .tag) \
+        .dshopImage.tag=\"$(cat .tag)\" \
         $(pwd)/devops/helm/values/dshop/${_ENVIRONMENT}.yaml
 
   # Ref: https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/helmfile
   - id: 'Update the Kubernetes Deployment'
-    name: "gcr.io/$PROJECT_ID/helmfile@sha256:69ec431b5a201df518e10c9def71fd38a844bdf1df06f5ff3b1226a5a070254b"
-    #name: "gcr.io/$PROJECT_ID/helmfile"
+    name: gcr.io/$PROJECT_ID/helmfile
     dir: devops/helm/
     env:
       - 'CLOUDSDK_COMPUTE_ZONE=us-west1-a'
@@ -74,7 +73,19 @@ steps:
     entrypoint: '/bin/bash'
     args:
       - '-c'
-      - "helmfile --debug --environment ${_ENVIRONMENT} sync"
+      - |
+        CLUSTER=$$(gcloud config get-value container/cluster)
+        PROJECT=$$(gcloud config get-value core/project)
+        ZONE=$$(gcloud config get-value compute/zone)
+
+        gcloud container clusters get-credentials "$${CLUSTER}" \
+          --project "$${PROJECT}" \
+          --zone "$${ZONE}"
+
+        helm repo add prometheus-community \
+          https://prometheus-community.github.io/helm-charts
+
+        helmfile --environment ${_ENVIRONMENT} sync
 
 timeout: '3600s'
 options:

--- a/devops/cloudbuild.dshop0.yaml
+++ b/devops/cloudbuild.dshop0.yaml
@@ -71,12 +71,10 @@ steps:
     env:
       - 'CLOUDSDK_COMPUTE_ZONE=us-west1-a'
       - 'CLOUDSDK_CONTAINER_CLUSTER=dshop0'
+    entrypoint: '/bin/bash'
     args:
-      [
-        "--environment",
-        "${_ENVIRONMENT}",
-        "sync",
-      ]
+      - '-c'
+      - "helmfile --debug --environment ${_ENVIRONMENT} sync"
 
 timeout: '3600s'
 options:

--- a/devops/cloudbuild.dshop0.yaml
+++ b/devops/cloudbuild.dshop0.yaml
@@ -13,13 +13,12 @@ steps:
       - '-c'
       - 'date +%Y%m%d%H%M%s > .tag'
 
-
   - id: 'Build docker image'
     name: 'gcr.io/cloud-builders/docker'
     args: [
       'build',
       '-f ./devops/Dockerfile',
-      '-t "gcr.io/$PROJECT_ID/${_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)"',
+      '-t "gcr.io/$PROJECT_ID/${_GCR_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)"',
       '--build-arg SENTRY_DSN=${_SENTRY_DSN}',
       '--build-arg ENVIRONMENT=${_ENVIRONMENT}',
       '$(pwd)'
@@ -32,7 +31,7 @@ steps:
       - '-c'
       - |
         docker push \
-          gcr.io/$PROJECT_ID/${_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)
+          gcr.io/$PROJECT_ID/${_GCR_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)
 
   - id: 'Tag the image'
     name: 'gcr.io/cloud-builders/gcloud'
@@ -41,14 +40,14 @@ steps:
       - '-c'
       - |
         gcloud container images add-tag \
-          "gcr.io/$PROJECT_ID/${_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)" \
-          "gcr.io/$PROJECT_ID/${_NAMESPACE}/${_IMAGE_NAME}:latest" \
+          "gcr.io/$PROJECT_ID/${_GCR_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)" \
+          "gcr.io/$PROJECT_ID/${_GCR_NAMESPACE}/${_IMAGE_NAME}:latest" \
           --quiet
 
         if [[ "$BRANCH_NAME" == "stable" ]]; then
           gcloud container images add-tag \
-            "gcr.io/$PROJECT_ID/${_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)" \
-            "gcr.io/$PROJECT_ID/${_NAMESPACE}/${_IMAGE_NAME}:mainnet" \
+            "gcr.io/$PROJECT_ID/${_GCR_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)" \
+            "gcr.io/$PROJECT_ID/${_GCR_NAMESPACE}/${_IMAGE_NAME}:mainnet" \
             --quiet
         fi
 

--- a/devops/cloudbuild.dshop0.yaml
+++ b/devops/cloudbuild.dshop0.yaml
@@ -19,12 +19,12 @@ steps:
     args:
       - '-c'
       - |
-      build \
-      -f ./devops/Dockerfile \
-      -t "gcr.io/$PROJECT_ID/${_GCR_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)" \
-      --build-arg SENTRY_DSN=${_SENTRY_DSN} \
-      --build-arg ENVIRONMENT=${_ENVIRONMENT} \
-      $(pwd)
+        build \
+          -f ./devops/Dockerfile \
+          -t "gcr.io/$PROJECT_ID/${_GCR_NAMESPACE}/${_IMAGE_NAME}:$(cat .tag)" \
+          --build-arg SENTRY_DSN=${_SENTRY_DSN} \
+          --build-arg ENVIRONMENT=${_ENVIRONMENT} \
+          $(pwd)
 
   - id: 'Push the image to GCR'
     name: 'gcr.io/cloud-builders/docker'

--- a/devops/cloudbuild.dshop0.yaml
+++ b/devops/cloudbuild.dshop0.yaml
@@ -65,7 +65,8 @@ steps:
 
   # Ref: https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/helmfile
   - id: 'Update the Kubernetes Deployment'
-    name: "gcr.io/$PROJECT_ID/helmfile"
+    name: "gcr.io/$PROJECT_ID/helmfile@sha256:69ec431b5a201df518e10c9def71fd38a844bdf1df06f5ff3b1226a5a070254b"
+    #name: "gcr.io/$PROJECT_ID/helmfile"
     dir: devops/helm/
     env:
       - 'CLOUDSDK_COMPUTE_ZONE=us-west1-a'

--- a/devops/cloudbuild.dshop0.yaml
+++ b/devops/cloudbuild.dshop0.yaml
@@ -53,14 +53,15 @@ steps:
             --quiet
         fi
 
-  - id: 'Set explicity version for this deployment'
+  - id: 'Set explicit version for this deployment'
     name: "gcr.io/$PROJECT_ID/yq"
-    args: [
-      'yq',
-      '-yi',
-      '.dshopImage.tag=$(cat .tag)',
-      'values/dshop/${_ENVIRONMENT}.yaml'
-    ]
+    entrypoint: '/bin/bash'
+    args:
+      - '-c'
+      - |
+        yq -yi \
+        .dshopImage.tag=$(cat .tag) \
+        values/dshop/${_ENVIRONMENT}.yaml
 
   # Ref: https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/helmfile
   - id: 'Update the Kubernetes Deployment'

--- a/devops/cloudbuild.dshop0.yaml
+++ b/devops/cloudbuild.dshop0.yaml
@@ -66,6 +66,7 @@ steps:
   # Ref: https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/helmfile
   - id: 'Update the Kubernetes Deployment'
     name: "gcr.io/$PROJECT_ID/helmfile"
+    dir: devops/helm/
     env:
       - 'CLOUDSDK_COMPUTE_ZONE=us-west1-a'
       - 'CLOUDSDK_CONTAINER_CLUSTER=dshop0'

--- a/devops/dockerfiles/cert-issuer-ingress
+++ b/devops/dockerfiles/cert-issuer-ingress
@@ -1,0 +1,17 @@
+FROM openresty/openresty:alpine-fat
+
+ENV AUTO_SSL_VERSION='0.13.1'
+
+RUN apk --no-cache add bash openssl \
+    && /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl $AUTO_SSL_VERSION \
+    # Remove nginx default config
+    && rm /etc/nginx/conf.d/default.conf
+
+COPY ./devops/dockerfiles/files/issuer-nginx.conf.template \
+	/usr/local/openresty/nginx/conf/nginx.conf.template
+COPY ./devops/dockerfiles/files/issuer-entrypoint.sh /entrypoint.sh
+
+VOLUME /etc/resty-auto-ssl
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/devops/dockerfiles/files/issuer-entrypoint.sh
+++ b/devops/dockerfiles/files/issuer-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Assumes a persistent disk exists at /etc that can be used to store certificates
+
+RESTY_CONF_DIR="/usr/local/openresty/nginx/conf"
+
+mkdir -p /etc/resty-auto-ssl/letsencrypt/conf.d
+
+# openresty will change it later on his own, right now we're just giving it access
+chmod 777 /etc/resty-auto-ssl
+
+# Check if dhparam.pem has already been generated, otherwise copy it
+if [ ! -f "/etc/resty-auto-ssl/dhparam.pem" ]; then
+  openssl dhparam -out /etc/resty-auto-ssl/dhparam.pem 2048
+fi
+
+if [ ! -f "/etc/resty-auto-ssl/resty-auto-ssl-fallback.key" ]; then
+  openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj '/CN=sni-support-required-for-valid-ssl' -keyout /etc/resty-auto-ssl/resty-auto-ssl-fallback.key -out /etc/resty-auto-ssl/resty-auto-ssl-fallback.crt
+fi
+
+envsubst '$SERVER_ENDPOINT,$REDIS_HOST,$REDIS_PORT,$REDIS_DB,$NGINX_RESOLVER_IP' \
+  < ${RESTY_CONF_DIR}/nginx.conf.template \
+  > ${RESTY_CONF_DIR}/nginx.conf
+
+echo "CONTACT_EMAIL='support@originprotocol.com'" > /etc/resty-auto-ssl/letsencrypt/conf.d/dehydrated.conf
+
+# If this CA isn't used, it will fail as v1 has been depreciated
+echo "CA=\"https://acme-v02.api.letsencrypt.org/directory\"" > /etc/resty-auto-ssl/letsencrypt/conf.d/ca.sh
+
+exec "$@"

--- a/devops/dockerfiles/files/issuer-nginx.conf.template
+++ b/devops/dockerfiles/files/issuer-nginx.conf.template
@@ -1,0 +1,126 @@
+events {
+  worker_connections 1024;
+}
+
+http {
+  include mime.types;
+  default_type application/octet-stream;
+  sendfile on;
+
+  # Sufficient for ~1000 separate domains
+  lua_shared_dict auto_ssl 10m;
+
+  # The "auto_ssl" shared dict is used to temporarily store various settings
+  # like the secret used by the hook server on port 8999. Do not change or
+  # omit it.
+  lua_shared_dict auto_ssl_settings 64k;
+
+  # A DNS resolver must be defined for OCSP stapling to function.
+  # resolver 8.8.8.8 ipv6=off;
+  # This should always be the GKE CoreDNS address
+  resolver $NGINX_RESOLVER_IP ipv6=off;
+
+  # Initial setup tasks.
+  init_by_lua_block {
+      auto_ssl = (require "resty.auto-ssl").new()
+      auto_ssl:set("ca", "https://acme-v02.api.letsencrypt.org/directory")
+      auto_ssl:set("storage_adapter", "resty.auto-ssl.storage_adapters.redis")
+
+      auto_ssl:set("redis", {
+        host = "$REDIS_HOST",
+        port = "$REDIS_PORT",
+        db = "$REDIS_DB"
+      })
+
+      --- Allow all domains
+      auto_ssl:set("allow_domain", function(domain)
+        return true
+      end)
+
+      auto_ssl:init()
+  }
+
+  init_worker_by_lua_block {
+      auto_ssl:init_worker()
+  }
+
+  # Internal server running on port 8999 for handling certificate tasks.
+  server {
+      listen 127.0.0.1:8999;
+
+      # Increase the body buffer size, to ensure the internal POSTs can always
+      # parse the full POST contents into memory.
+      client_body_buffer_size 128k;
+      client_max_body_size 128k;
+
+      location / {
+        content_by_lua_block {
+          auto_ssl:hook_server()
+        }
+      }
+  }
+
+  server {
+    listen 80 default_server;
+
+    # Access for LetsEncrypt
+    location /.well-known/acme-challenge/ {
+      auth_basic off;
+      content_by_lua_block {
+          auto_ssl:challenge_server()
+      }
+    }
+
+    # Force HTTPS
+    location / {
+      return 301 https://$host$request_uri;
+    }
+  }
+
+  server {
+    listen 443 ssl;
+
+    # Dynamic handler for issuing or returning certs for SNI domains.
+    ssl_certificate_by_lua_block {
+      auto_ssl:ssl_certificate()
+    }
+
+    # Define a fallback certificate so nginx can start
+    ssl_certificate /etc/resty-auto-ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/resty-auto-ssl/resty-auto-ssl-fallback.key;
+
+    # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+    ssl_dhparam /etc/resty-auto-ssl/dhparam.pem;
+
+    # intermediate configuration. tweak to your needs.
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
+    ssl_prefer_server_ciphers on;
+
+    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
+    # uncomment if you are sure you'll never drop HTTPS support
+    # add_header Strict-Transport-Security max-age=15768000;
+    location / {
+      proxy_pass http://$SERVER_ENDPOINT;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_buffering off;
+
+      more_clear_headers "Server: ";
+      more_set_headers "X-Frame-Options: SAMEORIGIN";
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-XSS-Protection: 1";
+      more_set_headers "Strict-Transport-Security: max-age=31536000";
+      more_set_headers "Expect-CT: max-age=86400";
+      more_set_headers "Feature-Policy: microphone 'none'";
+      more_set_headers "Content-Security-Policy: default-src https: 'unsafe-inline' 'unsafe-eval'; img-src https: data: blob:; frame-src https: 'unsafe-inline' 'unsafe-eval';";
+    }
+  }
+}

--- a/devops/helm/README.md
+++ b/devops/helm/README.md
@@ -1,0 +1,27 @@
+# Kubernetes Cluster Setup
+
+## Prerequisites
+
+### Origin Only
+
+- [Configure your CLI environment] https://github.com/oplabs/ops/blob/master/playbook/kubernetes/setup.md
+- [Install Helmfile](https://github.com/roboll/helmfile#installation)
+
+### Everybody
+
+- [Install Helm](https://github.com/roboll/helmfile#installation)
+- [Install and configure Helm Secrets](https://github.com/jkroepke/helm-secrets) if you want encrypted secrets.
+- [Install Helmfile](https://github.com/roboll/helmfile)
+
+## Install
+
+To install a Helm release:
+
+1) Create a values file for your release.  You can use `values/dshop/rinkeby.yaml` as an example.
+2) Install your dshop release with the appropriate values files `helm install -f charts/dshop/values.yaml -f path/to/myvalues.yaml`
+
+### Using Helmfile
+
+Update helmfile.yaml with your environment configuration, and sync it:
+
+    helmfile --environment=rinkeby sync

--- a/devops/helm/README.md
+++ b/devops/helm/README.md
@@ -25,3 +25,11 @@ To install a Helm release:
 Update helmfile.yaml with your environment configuration, and sync it:
 
     helmfile --environment=rinkeby sync
+
+## Helpful Notes
+
+### Multiple Helm Versions
+
+You may need to run multiple helm versions at once if you're working with multiple clusters with incompatible helm/tiller versions.  If you install another binary (say, `helm3`), you can add this to `hemlfile.yaml` to use your specific version of `helm`:
+
+    helmBinary: /path/to/bin/helm3

--- a/devops/helm/charts/dshop/.helmignore
+++ b/devops/helm/charts/dshop/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/devops/helm/charts/dshop/Chart.yaml
+++ b/devops/helm/charts/dshop/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: dshop
+description: A Helm chart for Dshop node
+type: application
+version: 0.1.0

--- a/devops/helm/charts/dshop/templates/NOTES.txt
+++ b/devops/helm/charts/dshop/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "dshop.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "dshop.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "dshop.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "dshop.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/devops/helm/charts/dshop/templates/_helpers.tpl
+++ b/devops/helm/charts/dshop/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dshop.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dshop.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dshop.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "dshop.labels" -}}
+helm.sh/chart: {{ include "dshop.chart" . }}
+{{ include "dshop.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "dshop.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dshop.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "dshop.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "dshop.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "dshopCacheStorage.fullname" -}}
+{{- printf "dshop-cache-storage" -}}
+{{- end -}}
+
+{{- define "dshopRedis.fullname" -}}
+{{- printf "dshop-redis-%s" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "issuer.fullname" -}}
+{{- printf "dshop-issuer-%s" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end -}}

--- a/devops/helm/charts/dshop/templates/_helpers.tpl
+++ b/devops/helm/charts/dshop/templates/_helpers.tpl
@@ -62,7 +62,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "dshopCacheStorage.fullname" -}}
-{{- printf "dshop-cache-storage" -}}
+{{- printf "dshop-cache-storage-%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "dshopRedis.fullname" -}}

--- a/devops/helm/charts/dshop/templates/dshop.balancer.yaml
+++ b/devops/helm/charts/dshop/templates/dshop.balancer.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "dshop.fullname" . }}-balancer
+  labels:
+    {{- include "dshop.selectorLabels" . | nindent 8 }}
+spec:
+  type: LoadBalancer
+  selector:
+    {{- include "dshop.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: 3000

--- a/devops/helm/charts/dshop/templates/dshop.deployment.yaml
+++ b/devops/helm/charts/dshop/templates/dshop.deployment.yaml
@@ -1,0 +1,135 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dshop.fullname" . }}
+  labels:
+    {{- include "dshop.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "dshop.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "dshop.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "dshop.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.dshopImage.repository }}:{{ .Values.dshopImage.tag | default .Values.dshopVersion }}"
+          imagePullPolicy: {{ .Values.dshopImage.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /health/status
+              port: http
+            failureThreshold: 10
+            periodSeconds: 7
+          livenessProbe:
+            httpGet:
+              path: /health/status
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 3
+          # Give Kubernetes time to do its thing (race error reduction)
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - sh
+                - -c
+                - "sleep 3"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: "{{ template "dshop.fullname" . }}-shared-cache"
+              mountPath: {{ .Values.sharedCacheDir }}
+          env:
+            - name: ENVIRONMENT
+              value: prod
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "dshop.fullname" . }}
+                  key: ENCRYPTION_KEY
+            - name: SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "dshop.fullname" . }}
+                  key: SESSION_SECRET
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "dshop.fullname" . }}
+                  key: DATABASE_URL
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "dshop.fullname" . }}
+                  key: SENTRY_DSN
+            - name: REDIS_URL
+              value: "redis://{{ template "dshopRedis.fullname" . }}-0.{{ template "dshopRedis.fullname" . }}.{{ default "default" .Release.Namespace }}.svc.cluster.local:6379/0"
+            - name: DSHOP_CACHE
+              value: "{{ .Values.sharedCacheDir }}/{{ .Values.environment }}"
+            - name: LOG_LEVEL
+              value: {{ default "INFO" .Values.logLevel }}
+            - name: EXTERNAL_IP
+              value: {{ .Values.dshopIssuerIp }}
+        - name: cloudsql-proxy
+          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          command: ["/cloud_sql_proxy",
+                    "-instances={{ .Values.dshopDBInstance }}=tcp:5432",
+                    "-credential_file=/secrets/cloudsql/credentials.json"]
+          securityContext:
+            runAsUser: 2  # non-root user
+            allowPrivilegeEscalation: false
+          volumeMounts:
+          - name: dshop-cloudsql-credentials
+            mountPath: /secrets/cloudsql
+            readOnly: true
+          # Don't kill DB connections before the backend process is terminated
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - sh
+                - -c
+                - "sleep 5"
+      volumes:
+        - name: dshop-cloudsql-credentials
+          secret:
+            secretName: dshop-cloudsql-credentials
+        - name: "{{ template "dshop.fullname" . }}-shared-cache"
+          persistentVolumeClaim:
+            claimName: "{{ template "dshopCacheStorage.fullname" . }}"
+            readOnly: false
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/devops/helm/charts/dshop/templates/dshop.deployment.yaml
+++ b/devops/helm/charts/dshop/templates/dshop.deployment.yaml
@@ -93,6 +93,11 @@ spec:
               value: {{ default "INFO" .Values.logLevel }}
             - name: EXTERNAL_IP
               value: {{ .Values.dshopIssuerIp }}
+            {{- if .Values.disableQueueProcessors }}
+            - name: DISABLE_QUEUE_PROCESSSORS
+              value: "true"
+            {{- end }}
+        {{- if .Values.dshopDBInstance }}
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:1.11
           command: ["/cloud_sql_proxy",
@@ -113,10 +118,13 @@ spec:
                 - sh
                 - -c
                 - "sleep 5"
+        {{- end }}
       volumes:
+        {{- if .Values.dshopDBInstance }}
         - name: dshop-cloudsql-credentials
           secret:
             secretName: dshop-cloudsql-credentials
+        {{- end }}
         - name: "{{ template "dshop.fullname" . }}-shared-cache"
           persistentVolumeClaim:
             claimName: "{{ template "dshopCacheStorage.fullname" . }}"

--- a/devops/helm/charts/dshop/templates/dshop.hpa.yaml
+++ b/devops/helm/charts/dshop/templates/dshop.hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "dshop.fullname" . }}
+  labels:
+    {{- include "dshop.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "dshop.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/devops/helm/charts/dshop/templates/dshop.ingress.yaml
+++ b/devops/helm/charts/dshop/templates/dshop.ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "dshop.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "dshop.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/devops/helm/charts/dshop/templates/dshop.service.yaml
+++ b/devops/helm/charts/dshop/templates/dshop.service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dshop.fullname" . }}
+  labels:
+    {{- include "dshop.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "dshop.selectorLabels" . | nindent 4 }}

--- a/devops/helm/charts/dshop/templates/dshop.serviceaccount.yaml
+++ b/devops/helm/charts/dshop/templates/dshop.serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dshop.serviceAccountName" . }}
+  labels:
+    {{- include "dshop.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/devops/helm/charts/dshop/templates/dshopcache.pvc.yaml
+++ b/devops/helm/charts/dshop/templates/dshopcache.pvc.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: "{{ template "dshopCacheStorage.fullname" . }}"
-  labels:
-    {{- include "dshop.selectorLabels" . | nindent 8 }}
 spec:
  accessModes:
  - ReadWriteMany

--- a/devops/helm/charts/dshop/templates/dshopcache.pvc.yaml
+++ b/devops/helm/charts/dshop/templates/dshopcache.pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ template "dshopCacheStorage.fullname" . }}"
+  labels:
+    {{- include "dshop.selectorLabels" . | nindent 8 }}
+spec:
+ accessModes:
+ - ReadWriteMany
+ storageClassName: ""
+ volumeName: {{ template "dshopCacheStorage.fullname" . }}
+ resources:
+   requests:
+     storage: {{ default "50Gi" .Values.dshopCacheStorageRequestSize }}

--- a/devops/helm/charts/dshop/templates/env.secrets.yaml
+++ b/devops/helm/charts/dshop/templates/env.secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "dshop.fullname" . }}
+  labels:
+    {{- include "dshop.selectorLabels" . | nindent 8 }}
+type: Opaque
+data:
+  ENCRYPTION_KEY: {{ required "Set .Values.dshopEncryptionKey" .Values.dshopEncryptionKey | b64enc | quote}}
+  SESSION_SECRET: {{ required "Set .Values.dshopSessionSecret" .Values.dshopSessionSecret | b64enc | quote}}
+  DATABASE_URL: {{ required "Set .Values.dshopDatabaseURL" .Values.dshopDatabaseURL | b64enc | quote}}
+  SENTRY_DSN: {{ required "Set .Values.dshopSentryDSN" .Values.dshopSentryDSN | b64enc | quote}}

--- a/devops/helm/charts/dshop/templates/issuer.sts.yaml
+++ b/devops/helm/charts/dshop/templates/issuer.sts.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "issuer.fullname" . }}
+  labels:
+    {{- include "dshop.selectorLabels" . | nindent 8 }}
+spec:
+  replicas: {{ default 1 .Values.dshopIssuerReplicas }}
+  selector:
+    matchLabels:
+      app: {{ template "issuer.fullname" . }}
+  serviceName: {{ template "issuer.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "issuer.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+      - name: issuer
+        image: "{{ .Values.issuerImage.repository }}:{{ default "latest" .Values.issuerImage.tag }}"
+        imagePullPolicy: {{ .Values.issuerImage.pullPolicy }}
+        ports:
+          - containerPort: 80
+        env:
+          - name: SERVER_ENDPOINT
+            value: "{{ template "dshop.fullname" . }}-balancer.{{ default "default" .Release.Namespace }}.svc.cluster.local:3000"
+          - name: REDIS_HOST
+            value: "{{ template "dshopRedis.fullname" . }}-0.{{ template "dshopRedis.fullname" . }}.{{ default "default" .Release.Namespace }}.svc.cluster.local"
+          - name: REDIS_PORT
+            value: "6379"
+          - name: REDIS_DB
+            value: "{{ default "0" .Values.issuerRedisDB }}"
+          - name: NGINX_RESOLVER_IP
+            value: "{{ .Values.issuerNginxResolver }}"
+        volumeMounts:
+          - name: {{ template "issuer.fullname" . }}-data
+            mountPath: /etc/resty-auto-ssl
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ template "issuer.fullname" . }}-data
+    spec:
+      storageClassName: "standard"
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 8Gi

--- a/devops/helm/charts/dshop/templates/issuer.svc.yaml
+++ b/devops/helm/charts/dshop/templates/issuer.svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "issuer.fullname" . }}
+  labels:
+    {{- include "dshop.selectorLabels" . | nindent 8 }}
+spec:
+  type: LoadBalancer
+  loadBalancerIP: {{ .Values.dshopIssuerIp }}
+  selector:
+    app: {{ template "issuer.fullname" . }}
+  ports:
+  - name: http
+    port: 80
+  - name: https
+    port: 443

--- a/devops/helm/charts/dshop/templates/nfs.pv.yaml
+++ b/devops/helm/charts/dshop/templates/nfs.pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ template "dshopCacheStorage.fullname" . }}
+  labels:
+    {{- include "dshop.selectorLabels" . | nindent 8 }}
+spec:
+ capacity:
+   storage: {{ default "50Gi" .Values.dshopCacheStorageRequestSize }}
+ accessModes:
+ - ReadWriteMany
+ nfs:
+   path: {{ .Values.dshopStorageNFSPath }}
+   server: {{ .Values.dshopStorageIP }}

--- a/devops/helm/charts/dshop/templates/redis.configmap.yaml
+++ b/devops/helm/charts/dshop/templates/redis.configmap.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "dshopRedis.fullname" . }}
+  labels:
+    {{- include "dshop.selectorLabels" . | nindent 8 }}
+data:
+  redis.conf: |+
+    dir /data/redis
+    cluster-enabled yes
+    cluster-require-full-coverage no
+    cluster-node-timeout 15000
+    cluster-config-file nodes.conf
+    cluster-migration-barrier 1 
+
+    # Restoring with RDB with appendonly https://stackoverflow.com/a/23233940/402412
+    appendonly yes
+
+    # Other cluster members need to be able to connect
+    protected-mode no
+
+  bootstrap-pod.sh: |+
+    #!/bin/sh
+    set -e
+
+    # Create the data dir
+    mkdir -p /data/redis
+
+    # Find which member of the Stateful Set this pod is running
+    ORDINAL=$(hostname | rev | cut -d- -f1)
+
+    # Only restore if the dump file exists and restore wasn't explicity disabled
+    if [[ -z "$DISABLE_RESTORE" && -f /data/redis/restore.rdb ]]; then
+      echo "Restore redis dump found.  Restoring..."
+      # move original data over if it exists
+      [[ -f /data/redis/dump.rdb ]] && mv /data/redis/dump.rdb /data/redis/dump.rdb.backup
+      [[ -f /data/redis/appendonly.aof ]] && mv /data/redis/appendonly.aof /data/redis/appendonly.aof.backup
+
+      # Move restore dump to where it will be loaded
+      mv /data/redis/restore.rdb /data/redis/dump.rdb
+    fi
+
+    # Launch a server instance so we can configure it
+    redis-server /config/redis.conf &
+
+    # TODO: Wait until redis-server process is ready
+    sleep 1
+
+    if [ $ORDINAL = "0" ]; then
+      echo "This is the MASTER node"
+
+      # The first member of the cluster should control all slots initially
+      redis-cli cluster addslots $(seq 0 16383)
+
+    else
+      echo "This is the SLAVE node. Master: $STS_NAME-0.$STS_NAME.$NAMESPACE.svc.cluster.local"
+
+      # Other members of the cluster join as slaves
+      MASTER_IP=$(echo "print inet_ntoa(scalar(gethostbyname('$STS_NAME-0.$STS_NAME.$NAMESPACE.svc.cluster.local')))" | perl -MSocket)
+      redis-cli cluster meet $MASTER_IP 6379
+      sleep 1
+
+      # Become the slave of a random master node
+      MASTER_ID=$(redis-cli --csv cluster slots | cut -d, -f 5 | sed -e 's/^"//'  -e 's/"$//')
+      redis-cli cluster replicate $MASTER_ID
+    fi

--- a/devops/helm/charts/dshop/templates/redis.sts.yaml
+++ b/devops/helm/charts/dshop/templates/redis.sts.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "dshopRedis.fullname" . }}
+  labels:
+    {{- include "dshop.selectorLabels" . | nindent 8 }}
+spec:
+  replicas: {{ default 2 .Values.dshopRedisReplicas }}
+  selector:
+    matchLabels:
+      app: {{ template "dshopRedis.fullname" . }}
+  serviceName: {{ template "dshopRedis.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "dshopRedis.fullname" . }}
+    spec:
+      initContainers:
+      - name: configure-redis
+        image: "{{ default "redis" .Values.dshopRedisImage }}:{{ .Values.dshopRedisImageTag }}"
+        command: ["/bin/bash", "/config/bootstrap-pod.sh"]
+        env:
+          - name: NAMESPACE
+            value: default
+          - name: STS_NAME
+            value: {{ template "dshopRedis.fullname" . }}
+        volumeMounts:
+          - mountPath: /data
+            name: {{ template "dshopRedis.fullname" . }}-redis
+          - mountPath: /config
+            name: config
+            readOnly: false
+      containers:
+      - name: redis
+        image: "{{ default "redis" .Values.dshopRedisImage }}:{{ .Values.dshopRedisImageTag }}"
+        command: ["redis-server",  "/config/redis.conf"]
+        volumeMounts:
+          - mountPath: /data
+            name: {{ template "dshopRedis.fullname" . }}-redis
+          - mountPath: /config
+            name: config
+            readOnly: false
+        ports:
+          - name: redis
+            containerPort: 6379
+          - name: gossip
+            containerPort: 16379
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "dshopRedis.fullname" . }}
+          items: 
+          - key: redis.conf
+            path: redis.conf
+          - key: bootstrap-pod.sh
+            path: bootstrap-pod.sh
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ template "dshopRedis.fullname" . }}-redis
+      labels:
+        app: {{ template "dshopRedis.fullname" . }}
+    spec:
+      accessModes:
+        - ReadWriteOnce  # Read-write for a single node only
+      storageClassName: "standard"
+      resources:
+        requests:
+          storage: {{ default "10Gi" .Values.dshopRedisStorageSize }}

--- a/devops/helm/charts/dshop/templates/redis.svc.yaml
+++ b/devops/helm/charts/dshop/templates/redis.svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "dshopRedis.fullname" . }}
+  labels:
+    {{- include "dshop.selectorLabels" . | nindent 8 }}
+spec:
+  clusterIP: None
+  selector:
+    app: {{ template "dshopRedis.fullname" . }}
+  ports:
+  - name: redis
+    port: 6379
+  - name: gossip
+    port: 16379

--- a/devops/helm/charts/dshop/templates/tests/test-connection.yaml
+++ b/devops/helm/charts/dshop/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "dshop.fullname" . }}-test-connection"
+  labels:
+    {{- include "dshop.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "dshop.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/devops/helm/charts/dshop/values.yaml
+++ b/devops/helm/charts/dshop/values.yaml
@@ -1,0 +1,91 @@
+replicaCount: 3
+
+dshopImage:
+  repository: ""
+  pullPolicy: IfNotPresent
+  # Defaults to Chart dshopVersion if not overridden here
+  tag: ""
+
+issuerImage:
+  repository: ""
+  pullPolicy: IfNotPresent
+  # Defaults to Chart dshopVersion if not overridden here
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations:
+  app: dshop
+  app.kubernetes.io/component: backend
+  app.kubernetes.io/part-of: dshop-backend-mainnet
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: NodePort
+  port: 3000
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  requests:
+    memory: 1Gi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Root path used for the shared cache (shop deployments, etc)
+sharedCacheDir: /data/dshop-cache
+# Must be set for Cloud SQL connection
+dshopDBInstance: ""
+# Must be reserved and set for each environment
+dshopIssuerIp: ""
+#dshopCacheStorageRequestSize: ""
+#dshopRedisImage: ""
+dshopRedisImageTag: 6.2
+#dshopRedisStorageSize: 10Gi
+
+# The redis DB to use for storing certs for the issuers
+#issuerRedisDB: 1
+issuerNginxResolver: "8.8.8.8"

--- a/devops/helm/helmfile.yaml
+++ b/devops/helm/helmfile.yaml
@@ -6,8 +6,10 @@ releases:
       - charts/dshop/values.yaml
       - values/dshop/{{ .Environment.Name }}.yaml
       - environment: "{{ .Environment.Name }}"
+    {{- if ne .Environment.Name "default" }}
     secrets:
       - values/dshop/secrets.{{ .Environment.Name }}.yaml
+    {{- end }}
 
   # This is only one deployment, but the sync will happen
   # for every environment

--- a/devops/helm/helmfile.yaml
+++ b/devops/helm/helmfile.yaml
@@ -13,13 +13,14 @@ releases:
 
   # This is only one deployment, but the sync will happen
   # for every environment
-  - name: prometheus-operator
-    namespace: monitoring
-    chart: prometheus-community/prometheus-operator
-    values:
-      - values/monitoring/values.yaml
-    secrets:
-      - values/monitoring/secrets.yaml
+  # TODO: Disabled because of RBAC deployment issues
+  # - name: prometheus-operator
+  #   namespace: monitoring
+  #   chart: prometheus-community/prometheus-operator
+  #   values:
+  #     - values/monitoring/values.yaml
+  #   secrets:
+  #     - values/monitoring/secrets.yaml
 missingFileHandler: Error
 # The below values are NOT CHART VALUES, it's weird. They seem to
 # be only values you can use here in this helmfile.  The regular

--- a/devops/helm/helmfile.yaml
+++ b/devops/helm/helmfile.yaml
@@ -1,4 +1,3 @@
-helmBinary: /home/mike/.local/bin/helm3
 releases:
   - name: "dshop-{{ .Environment.Name }}"
     namespace: default

--- a/devops/helm/helmfile.yaml
+++ b/devops/helm/helmfile.yaml
@@ -13,7 +13,10 @@ releases:
 
   # This is only one deployment, but the sync will happen
   # for every environment
-  # TODO: Disabled because of RBAC deployment issues
+  #
+  # TODO: Disabled because of RBAC deployment issues with
+  # Cloudbuild.
+  #
   # - name: prometheus-operator
   #   namespace: monitoring
   #   chart: prometheus-community/prometheus-operator

--- a/devops/helm/helmfile.yaml
+++ b/devops/helm/helmfile.yaml
@@ -1,3 +1,4 @@
+helmBinary: /home/mike/.local/bin/helm3
 releases:
   - name: "dshop-{{ .Environment.Name }}"
     namespace: default
@@ -30,12 +31,9 @@ environments:
   default:
     values:
       - charts/dshop/values.yaml
-      - dshopVersion: latest
   mainnet:
     values:
       - charts/dshop/values.yaml
-      - dshopVersion: 2021021721071613596036
   rinkeby:
     values:
       - charts/dshop/values.yaml
-      - dshopVersion: 2021021721071613596020

--- a/devops/helm/helmfile.yaml
+++ b/devops/helm/helmfile.yaml
@@ -1,0 +1,39 @@
+releases:
+  - name: "dshop-{{ .Environment.Name }}"
+    namespace: default
+    chart: charts/dshop
+    values:
+      - charts/dshop/values.yaml
+      - values/dshop/{{ .Environment.Name }}.yaml
+      - environment: "{{ .Environment.Name }}"
+    secrets:
+      - values/dshop/secrets.{{ .Environment.Name }}.yaml
+
+  # This is only one deployment, but the sync will happen
+  # for every environment
+  - name: prometheus-operator
+    namespace: monitoring
+    chart: prometheus-community/prometheus-operator
+    values:
+      - values/monitoring/values.yaml
+    secrets:
+      - values/monitoring/secrets.yaml
+missingFileHandler: Error
+# The below values are NOT CHART VALUES, it's weird. They seem to
+# be only values you can use here in this helmfile.  The regular
+# chart values are added here just to be accessible and future
+# reference but aren't used currently.
+environments:
+  # default env is only used in linting
+  default:
+    values:
+      - charts/dshop/values.yaml
+      - dshopVersion: latest
+  mainnet:
+    values:
+      - charts/dshop/values.yaml
+      - dshopVersion: 2021021721071613596036
+  rinkeby:
+    values:
+      - charts/dshop/values.yaml
+      - dshopVersion: 2021021721071613596020

--- a/devops/helm/values/dshop/README.md
+++ b/devops/helm/values/dshop/README.md
@@ -10,12 +10,13 @@ The following values are required to be defined for an environment unless specif
 - `dshopIssuerIp`: The IP address to use for the issuer.  This is probably an already-reserved GCP public IP
 - `dshopCacheStorageRequestSize`: This should probably be the same across environments.  The charts currently share this cache because it's expensive and large.
 - `dshopStorageNFSPath`: The NFS share path to use for the cache NFS store
+- `disableQueueProcessors`: Do not run bull queue processors
 
 ### Secrets
 
 - `dshopStorageIP`: NFS Storage IP for Dshop cache
-- `dshopDBInstance`: GCP Cloud SQL instance the proxy will make a connection with
 - `dshopEncryptionKey`: Encryption key used to encrypt sensitive data in the DB
 - `dshopSessionSecret`: The secret key used to encrypt session data
-- `dshopDatabaseURL`: PostgreSQL URL to the database.  The host will be `localhost` if using `cloud_sql_proxy` which is currently required.  e.g. `postgresql://username:password@127.0.0.1:5432/dshop`
+- `dshopDBInstance`: GCP Cloud SQL instance the proxy will make a connection with
+- `dshopDatabaseURL`: PostgreSQL URL to the database.  The host will be `localhost` if using `cloud_sql_proxy` (and setting `dshopDBInstance` above).  e.g. `postgresql://username:password@127.0.0.1:5432/dshop`
 - `dshopSentryDSN`: An optional [Sentry](https://sentry.io/) DSN if you want errors reported

--- a/devops/helm/values/dshop/README.md
+++ b/devops/helm/values/dshop/README.md
@@ -1,0 +1,21 @@
+# Dshop Values
+
+The following values are required to be defined for an environment unless specifically mentioned as optional.  If you're looking to stand up your own Dshop kubernetes environment, you need to create a values file with these.
+
+## Environment Specific
+
+### Values
+
+- `issuerNginxResolver`: The DNS resolver the issuer NGINX should use.  Generally, this needs to be able to resolve the name for redis.  In a Kubernetes cluster, this is probably `<k8s-subnet>.10`
+- `dshopIssuerIp`: The IP address to use for the issuer.  This is probably an already-reserved GCP public IP
+- `dshopCacheStorageRequestSize`: This should probably be the same across environments.  The charts currently share this cache because it's expensive and large.
+- `dshopStorageNFSPath`: The NFS share path to use for the cache NFS store
+
+### Secrets
+
+- `dshopStorageIP`: NFS Storage IP for Dshop cache
+- `dshopDBInstance`: GCP Cloud SQL instance the proxy will make a connection with
+- `dshopEncryptionKey`: Encryption key used to encrypt sensitive data in the DB
+- `dshopSessionSecret`: The secret key used to encrypt session data
+- `dshopDatabaseURL`: PostgreSQL URL to the database.  The host will be `localhost` if using `cloud_sql_proxy` which is currently required.  e.g. `postgresql://username:password@127.0.0.1:5432/dshop`
+- `dshopSentryDSN`: An optional [Sentry](https://sentry.io/) DSN if you want errors reported

--- a/devops/helm/values/dshop/default.yaml
+++ b/devops/helm/values/dshop/default.yaml
@@ -1,0 +1,17 @@
+# This is probably not the values file you want to use.  It's used
+# for linting, and maybe as an example of what you need to define
+dshopImage:
+  repository: "experimental/dshop-backend"
+
+issuerImage:
+  repository: "prod/origin-dapp-creator-issuer"
+
+dshopCacheStorageRequestSize: 1T
+dshopIssuerIp: 127.0.0.1
+
+# Secrets
+dshopEncryptionKey: asdf1234
+dshopSessionSecret: asdf1234
+dshopDatabaseURL: postgresql://127.0.0.1:5432/dshop
+dshopSentryDSN: ""
+dshopStorageNFSPath: /dshop_cache

--- a/devops/helm/values/dshop/default.yaml
+++ b/devops/helm/values/dshop/default.yaml
@@ -15,3 +15,4 @@ dshopSessionSecret: asdf1234
 dshopDatabaseURL: postgresql://127.0.0.1:5432/dshop
 dshopSentryDSN: ""
 dshopStorageNFSPath: /dshop_cache
+disableQueueProcessors: false

--- a/devops/helm/values/dshop/mainnet.yaml
+++ b/devops/helm/values/dshop/mainnet.yaml
@@ -6,6 +6,8 @@ issuerImage:
   repository: gcr.io/origin-214503/dshop/cert-issuer-ingress
   tag: "20210224172035"
 
+replicaCount: 6
+
 dshopCacheStorageRequestSize: 1T
 dshopIssuerIp: 35.247.127.81
 dshopIssuerReplicas: 2

--- a/devops/helm/values/dshop/mainnet.yaml
+++ b/devops/helm/values/dshop/mainnet.yaml
@@ -1,6 +1,6 @@
 dshopImage:
   repository: gcr.io/origin-214503/experimental/dshop-backend
-  tag: "2021022321221614115370"
+  tag: "mainnet"
 
 issuerImage:
   repository: gcr.io/origin-214503/dshop/cert-issuer-ingress

--- a/devops/helm/values/dshop/mainnet.yaml
+++ b/devops/helm/values/dshop/mainnet.yaml
@@ -15,4 +15,4 @@ dshopStorageNFSPath: /dshop_cache
 # Likely .10 on the k8s subnet
 issuerNginxResolver: 10.64.0.10
 
-disableQueueProcessors: false
+disableQueueProcessors: true

--- a/devops/helm/values/dshop/mainnet.yaml
+++ b/devops/helm/values/dshop/mainnet.yaml
@@ -14,3 +14,5 @@ dshopStorageNFSPath: /dshop_cache
 # Resolver that needs to also see redis.
 # Likely .10 on the k8s subnet
 issuerNginxResolver: 10.64.0.10
+
+disableQueueProcessors: false

--- a/devops/helm/values/dshop/mainnet.yaml
+++ b/devops/helm/values/dshop/mainnet.yaml
@@ -1,5 +1,5 @@
 dshopImage:
-  repository: gcr.io/origin-214503/experimental/dshop-backend
+  repository: gcr.io/origin-214503/dshop/dshop-backend
   tag: "mainnet"
 
 issuerImage:

--- a/devops/helm/values/dshop/mainnet.yaml
+++ b/devops/helm/values/dshop/mainnet.yaml
@@ -1,0 +1,16 @@
+dshopImage:
+  repository: gcr.io/origin-214503/experimental/dshop-backend
+  tag: "2021022321221614115370"
+
+issuerImage:
+  repository: gcr.io/origin-214503/dshop/cert-issuer-ingress
+  tag: "20210224172035"
+
+dshopCacheStorageRequestSize: 1T
+dshopIssuerIp: 35.247.127.81
+dshopIssuerReplicas: 2
+dshopStorageNFSPath: /dshop_cache
+
+# Resolver that needs to also see redis.
+# Likely .10 on the k8s subnet
+issuerNginxResolver: 10.64.0.10

--- a/devops/helm/values/dshop/rinkeby.yaml
+++ b/devops/helm/values/dshop/rinkeby.yaml
@@ -14,3 +14,5 @@ dshopStorageNFSPath: /dshop_cache
 # Resolver that needs to also see redis.
 # Likely .10 on the k8s subnet
 issuerNginxResolver: 10.64.0.10
+
+disableQueueProcessors: false

--- a/devops/helm/values/dshop/rinkeby.yaml
+++ b/devops/helm/values/dshop/rinkeby.yaml
@@ -1,0 +1,16 @@
+dshopImage:
+  repository: gcr.io/origin-214503/experimental/dshop-backend
+  tag: "2021022321221614115370"
+
+issuerImage:
+  repository: gcr.io/origin-214503/dshop/cert-issuer-ingress
+  tag: "20210225114406"
+
+dshopCacheStorageRequestSize: 1T
+dshopIssuerIp: 34.105.16.10
+dshopIssuerReplicas: 2
+dshopStorageNFSPath: /dshop_cache
+
+# Resolver that needs to also see redis.
+# Likely .10 on the k8s subnet
+issuerNginxResolver: 10.64.0.10

--- a/devops/helm/values/dshop/rinkeby.yaml
+++ b/devops/helm/values/dshop/rinkeby.yaml
@@ -1,6 +1,6 @@
 dshopImage:
   repository: gcr.io/origin-214503/experimental/dshop-backend
-  tag: "2021022321221614115370"
+  tag: "latest"
 
 issuerImage:
   repository: gcr.io/origin-214503/dshop/cert-issuer-ingress

--- a/devops/helm/values/dshop/rinkeby.yaml
+++ b/devops/helm/values/dshop/rinkeby.yaml
@@ -1,5 +1,5 @@
 dshopImage:
-  repository: gcr.io/origin-214503/experimental/dshop-backend
+  repository: gcr.io/origin-214503/dshop/dshop-backend
   tag: "latest"
 
 issuerImage:

--- a/devops/helm/values/dshop/secrets.mainnet.yaml
+++ b/devops/helm/values/dshop/secrets.mainnet.yaml
@@ -1,0 +1,19 @@
+dshopEncryptionKey: ENC[AES256_GCM,data:pYPVAE91zj7m6VVbbFoLnD23dKHO904dEtNMejDw3AM=,iv:nL03YJ4CqvldZXN4GqgAPu8Kah9GkyaIGR2hndIzC2k=,tag:Cqe3Vx/nUaG6W3TeM71FVw==,type:str]
+dshopSessionSecret: ENC[AES256_GCM,data:d7L1SNvfnZjxjmE1yqAyNS7ShrJwFgpIJPgD24JIuzI=,iv:tQmSS3HkbDYvQCS4Py5lbLlbncJjMGmjmIFVrfnkIHE=,tag:TPJ8EIpW3IX4ARrXrZp6Vg==,type:str]
+dshopDatabaseURL: ENC[AES256_GCM,data:rc6jMI4pjqc9eMFuU7Z8YwxSKQe3tX9MNltnrSIkakb1yDsvAunTF77KkBR9IVoQljYz+oGQe+ok7BficgXp6UlaBhOh+Y4mMQ==,iv:EIxwaqXPEs/lr7YG/V/KZc9NVdWwygoyqv2c2IPJrwk=,tag:LVGCthI5Pt+IdcIXlI6avw==,type:str]
+dshopDBInstance: ENC[AES256_GCM,data:l3T/gqVKdnt9JZbpYU3p3P+vW6xC2DsrhYBRWIWcb4Q1MJ3bjw==,iv:ZFTf7VM6a8C7T9JSr4UQuox/XdI6c7M4KmxeihgyyxY=,tag:5G8dl/QuXWZju/yXsXYhQQ==,type:str]
+dshopSentryDSN: ENC[AES256_GCM,data:mOS4gMWhWk8w1I6FzPzQNpgSLlbrxkNoQafEJKjC+TVMZh0eomItx+DYeir/BJV3vE6kMozHsSDdZqKty1eJA9MWPT7pSrjVgQ==,iv:363LX/99qSjDsqom5EwYGzkXxJnX3nFoVl1gk6zfoKE=,tag:Ri35qc0lVvRTUnwV93OpcA==,type:str]
+dshopStorageIP: ENC[AES256_GCM,data:WS0ty6snZgEFEIY=,iv:/uz5TUlo5AXAqMTxjdILioUrVOqx3h0qyBwzhxWq3ME=,tag:7G99hm8GymzFzZ92ND/bNA==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+    -   resource_id: projects/origin-214503/locations/global/keyRings/origin/cryptoKeys/origin
+        created_at: '2021-02-20T02:18:57Z'
+        enc: CiUAspr50q1chccpSHM5MzbAZzcSt+lBOFdv/aLWuBIwXIAeMQBqEkkA9SYlkweKwQNLzrd0m2hBQR4dRGy7RID8LmN/l49kyo7HFCVFTZhzMBTM+X2fhFg8twMB7MajuynfaDcNjcbeanZ83CXaKmqr
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-02-25T01:41:50Z'
+    mac: ENC[AES256_GCM,data:/Hafs6sjQtFqxmz7RJyLTSAiv9mOpWKqt9Z0dINxSfBT4sM0pbSPX58gaU7nVemr706Yqn60dFgxQvJz2gLUDRfhHwHfobzCnFBKA9t5VNx6gABI4BK/XdFKSCaZIqubW1oO9wPoypl0jJvlyJcQoojEO/c98PyiNwUxTzj9ldI=,iv:L5iPWXdVRpkFg9CXWT846ouGHlC03p8TxSBcsRn2HfY=,tag:RRqQMWIOuRNM4Ay9GrVWdQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1

--- a/devops/helm/values/dshop/secrets.rinkeby.yaml
+++ b/devops/helm/values/dshop/secrets.rinkeby.yaml
@@ -1,0 +1,19 @@
+dshopEncryptionKey: ENC[AES256_GCM,data:qmve+RXbjAE=,iv:KAezR4RAHiu4TcOLwkEOYHyUGTZD3+8WG3WH2n27cRI=,tag:Q6dtVnDz9rwgYFNyEsrnlw==,type:str]
+dshopSessionSecret: ENC[AES256_GCM,data:yudxodvAZuxpJSvug1S1tOUeJaJb07DkmtpuStwrgMw=,iv:nPzQLv93bmmjq8yzm7KCbtm8Q/M9C9o542ASZuP+FFU=,tag:EjEJkT3ee2ZGo/HflKJ6+w==,type:str]
+dshopDatabaseURL: ENC[AES256_GCM,data:kqN3+f98qbE660w+lKxSg+nwrqSm6UGbYlSzOccBq11m508hSxX9azv2IhFqHBdJlMYZSmt1j/6QA7eEp4MeEkaUeHHE,iv:aM+TUNtN6yAqvqR70Zsr8WwXacuWLlbUDUfD0cjDZ2A=,tag:wN3DmxsTku+LlcgJ/tODAg==,type:str]
+dshopDBInstance: ENC[AES256_GCM,data:OH9RMsIgIffUaIgTMlaZMML3M4ywCQthVrnDbtW0zZlvIVrs1w==,iv:uFkN71vE4HJ7v85T2K26/BvY7/AO5QIGZ7k5/dlDCOA=,tag:vkA/f9bs0Xl3Y665XWUD5w==,type:str]
+dshopSentryDSN: ENC[AES256_GCM,data:3kU5+7fcyLHbn0Y0jmMPf5fLpKJWz6wskFE9hzN+zHpCr6bEg9AG2k9gVhlNSECtI0rBfxueSslrY0AHE9TNZxFbfxyx6oezGw==,iv:BojA8Tec6hq/hRk+73em2zNjGfov4sar8Ure0B3+dFo=,tag:3X9+IuUffsHPAHdhAv3poQ==,type:str]
+dshopStorageIP: ENC[AES256_GCM,data:wPLB0QYBSp93tlw=,iv:sZburslSQv7gJCKWJYxwgsIlhm6SEUJpFun4enXmiWA=,tag:T2buLUSQ8fVs3nFnQbcS7w==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+    -   resource_id: projects/origin-214503/locations/global/keyRings/origin/cryptoKeys/origin
+        created_at: '2021-02-20T04:55:31Z'
+        enc: CiUAspr50qs13bMNefPiMQNOKGX1Ks9NxS6akNvlDS96oLVnfaGbEkkA9SYlkyQLfVODiCuBYv6RW1wfMx0WKFUj6fmcp43DurVAAqbjAO2lIhFqPP8SCvPYwPXY/yatSE09/qyr+YlhOdOxch+leIMs
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-02-25T21:54:48Z'
+    mac: ENC[AES256_GCM,data:g0HA4OIEKiIy+5WQyj1vR+qIoUUMequ0GbXM6dS38HAdpgYYEQqDGVVPEpA/SX3tVsrrqzpzphFQn8fIMnnyr1mAv6l1BgbNC4hL2LJNVjzjYvurkMNxPXwiFGIqhCsNMvbV/Z8tKyuwZuM2xIDqaFWsACOGSbD1DPWw4K8hUVw=,iv:CzcDcPeuv+WomSDePomZEZGVro1ZN5RD2LQkcsM4pC8=,tag:pIAnHe260zAyudH1Y0CLLg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1

--- a/devops/helm/values/monitoring/secrets.yaml
+++ b/devops/helm/values/monitoring/secrets.yaml
@@ -1,0 +1,14 @@
+data: ENC[AES256_GCM,data:vK6oHDf/f1g4ULwBByH8vMLmM2KUA0FQVAwdALl0RkGfhnnjnrK/19V4Aa2SoyFLB6BdLgqx6w8EOGO7tT1xkNcpmlWyNhF4K9wylMrLR1ly62nLRGO8gXIQuhXtb6ewnkWKyt1vtBGfHfMKq+9EbbLA3/SQidDtc+2OJSssq8WsZnmL5bBEMp6gQJT+tdNY6B8Ywnd1tnmUDBiR5AbBFlwnreM+hdoGIt+apLlhPN45GTD1LlsDrPHb+IwXL/8Y,iv:s1OiomMFQBFrJCs977zpmKYwyCp6XkSDlXp7Tn2ii94=,tag:T7rNRAI1GU3uXS9CdxEQsQ==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+    -   resource_id: projects/origin-214503/locations/global/keyRings/origin/cryptoKeys/origin
+        created_at: '2021-02-20T05:01:52Z'
+        enc: CiUAspr50kkq4WBPyMKZG9drVg8ThCo1mNzbZuV49OYVszDmqXHdEkkA9SYlk+RMP5y1ba/hvj4QW6ixSbLu4G9ixKmKWugW18kB6dl/8oD8ciS0sOnalOk9/FvgcImwhefHaBPN4XWGCMAsIp9p6VKQ
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-02-20T05:07:20Z'
+    mac: ENC[AES256_GCM,data:nSjJGeULYJ20v1HiZUNbyiBODtOupePMGOtSmxqU44kvJC1ZapV2CtXgm7KW98SmTJsAvp6RINARsVkgboIZw5mMFmqUOJmi0p3Tr4oYm/y+VJUQ4OEqksO31UmQooRe2YHcP9IOtyxkPMQ+qwdVYtkrco6XmHzTsMwUoojY1Z8=,iv:y1Zs/bFKxqk4ST5ZKJwHHuhu952a5oG9cjEwT4BrgLk=,tag:3gnmexKz8UE/t7CI7sdOgw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1

--- a/devops/helm/values/monitoring/values.yaml
+++ b/devops/helm/values/monitoring/values.yaml
@@ -1,0 +1,21 @@
+grafana:
+  grafana.ini:
+    smtp:
+      enabled: true
+      skip_verify: true
+      host: smtp.sendgrid.net:2525
+      from_address: no-reply@originprotocol.com
+  dashboardsConfigMaps:
+    default: grafana-dashboards-default
+  dashboardProviders:
+    dashboardproviders.yaml:
+        apiVersion: 1
+        providers:
+        - name: default
+          orgId: 1
+          folder: ''
+          type: file
+          disableDeletion: false
+          editable: true
+          options:
+              path: /var/lib/grafana/dashboards/default


### PR DESCRIPTION
Adds new helm charts, dockerfiles, etc for new cluster.  Includes some improvements as well.

- Issuer (lua-resty-autossl) is now redundant and scalable.  It will use Redis to store certificates
- Deployments are simplified with [`helmfile`](https://github.com/roboll/helmfile) (generally won't be manual, but run via cloudbuild)
- Each network "node" is a helmfile environment, which are individual helm releases, both on the `default` namespace
- dshop instances are now Kubernetes Deployments and not StatefulSets, making scaling simpler/cleaner
- [helm secrets](https://github.com/OriginProtocol/dshop/pull/new/devnewops) now used for secret handling, which uses GCP keystore for encryption/decryption behind the scenes.  Simplifies editing and interaction (e.g. `helm secrets edit path/to/file.yaml`)

