### PR TITLE
Adds the ability to disable queue processing

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -19,7 +19,9 @@ const { scheduleDNSVerificationJob } = require('./queues/dnsStatusProcessor')
 
 const log = getLogger('app')
 
-require('./queues').runProcessors()
+if (typeof process.env.DISABLE_QUEUE_PROCESSSORS === 'undefined') {
+  require('./queues').runProcessors()
+}
 scheduleDNSVerificationJob()
 
 const ORIGIN_WHITELIST_ENABLED = false


### PR DESCRIPTION
Don't want a second set of queue processors running on separate state storage when I bring up the second mainnet environment.  This adds a way to disable them.