### PR TITLE
fix new product selected collections

### DIFF
--- a/shop/src/pages/admin/products/Edit.js
+++ b/shop/src/pages/admin/products/Edit.js
@@ -263,7 +263,7 @@ const EditProduct = () => {
           .map((c) => c.id)
       })
     }
-  }, [collections.length, productId])
+  }, [collections, productId])
 
   useEffect(() => {
     if (hasOptions && (!formState.options || !formState.options.length)) {


### PR DESCRIPTION
Fixes #930

When a new product was saved the selected collections would clear. This was caused by listening on changes to `collections.length`. After the product was pushed to the DB and fetched, the useEffect() would not update bc even though collections had changed `collections.length` did not change.