### PR TITLE
Case Insensitive Login

### DIFF
--- a/backend/db/migrations/20210504183956-update-email-lowercase.js
+++ b/backend/db/migrations/20210504183956-update-email-lowercase.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface) => {
+    const q = 'UPDATE sellers SET email = lower(email);'
+    return queryInterface.sequelize.query(q)
+  },
+
+  down: () => Promise.resolve()
+};

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -227,7 +227,8 @@ module.exports = function (router) {
   })
 
   router.post('/auth/login', async (req, res) => {
-    const seller = await Seller.findOne({ where: { email: req.body.email } })
+    const email = req.body.email.toLowerCase()
+    const seller = await Seller.findOne({ where: { email } })
     if (!seller) {
       log.debug('Login failed: no such user')
       return res.send(AUTH_FAILURE_RESPOSNE)

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -73,6 +73,7 @@ module.exports = function (router) {
     }
 
     const fields = pick(req.body, 'name', 'email', 'superuser')
+    fields.email = email // use lower case email
     const passwordPlain = req.body.password
     if (passwordPlain) {
       const salt = await createSalt()

--- a/backend/utils/sellers.js
+++ b/backend/utils/sellers.js
@@ -81,9 +81,10 @@ async function createSeller({ name, email, password }, opts) {
     return { status: 400, error: 'Invalid registration' }
   }
   const { superuser, skipEmailVerification } = opts || {} // Superuser creation must be done explicitly
+  email = email.toLowerCase()
 
   const sellerCheck = await Seller.findOne({
-    where: { email: email.toLowerCase() }
+    where: { email }
   })
 
   if (sellerCheck) {
@@ -95,7 +96,7 @@ async function createSeller({ name, email, password }, opts) {
 
   const seller = await Seller.create({
     name,
-    email: email.toLowerCase(),
+    email,
     password: passwordHash,
     superuser: superuser,
     emailVerified: false,


### PR DESCRIPTION
User-provided email is used in the following endpoints to either create a seller, update a seller, or compare to an existing seller. I checked all of these places to make sure emails were being converted to lowercase.

* user login ( `/auth/login` )
* superuser login ( `/superuser/login` )
* first time sign up ( `/auth/registration` )
* regular sign up ( `/register` )
* edit user ( `/superuser/users/{userId}` )
* forgot password ( `/forgot-password` )


Resolves #928 