### PR TITLE
Adjusting the formula that calculates total taxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ devops/github
 *.dec.yaml
 
 dshop_setup
+
+# Other #
+.prettierrc.json

--- a/packages/utils/calculateCartTotal.js
+++ b/packages/utils/calculateCartTotal.js
@@ -7,12 +7,12 @@ const get = require('lodash/get')
  * @param {Object} cart Cart data object
  *
  * @returns {{
- *  total {Number}
- *  subTotal {Number}
- *  shipping {Number}
- *  discount {Number}
- *  donation {Number}
- *  totalTaxes {Number}
+ *  total {Number},
+ *  subTotal {Number},
+ *  shipping {Number},
+ *  discount {Number},
+ *  donation {Number},
+ *  totalTaxes {Number},
  *  taxRate {Number}
  * }}
  */
@@ -25,6 +25,10 @@ const calculateCartTotal = (cart) => {
 
   const shipping = get(cart, 'shipping.amount', 0)
   const taxRate = parseFloat(get(cart, 'taxRate', 0))
+  //The attribute 'taxRate' of the 'cart' object contains the tax rate as a fixed point number with a scaling factor of 1/100
+  //In other words, this number will need to be multiplied by 1/100 to get the tax rate in percentage.
+  //[Sources: 'dshop/shop/src/pages/admin/settings/checkout/_CountryTaxEntry.js', 'dshop/shop/src/utils/formHelpers.js']
+  const totalTaxes = Math.ceil(((taxRate / 100) * subTotal) / 100)
 
   const discountObj = get(cart, 'discountObj', {})
   const {
@@ -68,7 +72,6 @@ const calculateCartTotal = (cart) => {
 
   const donation = get(cart, 'donation', 0)
 
-  const totalTaxes = Math.ceil(taxRate * subTotal)
   const total = Math.max(
     0,
     subTotal + shipping - discount + donation + totalTaxes

--- a/shop/translation/crowdin/all-messages.json
+++ b/shop/translation/crowdin/all-messages.json
@@ -880,6 +880,6 @@
   "ZxOHPcWjsu9+0ENH6gSKiA==": "Terms",
   "qnZnUg0OB7k+75Mg5Tb3ng==": "Powered by Origin Dshop",
   "MTbzIIPfLSiuG9A5leCjiw==": "© Origin Protocol {VAR_YEAR_B64_eWVhcg}",
-  "y1XLjhDfGPVB8olV9Pp0Ow==": "Sorry, there was an error calculating shipping costs.",
-  "EF6JpB5si/Dul6Y8wkH/UA==": "© {VAR_YEAR_B64_eWVhcg} Origin Protocol"
+  "EF6JpB5si/Dul6Y8wkH/UA==": "© {VAR_YEAR_B64_eWVhcg} Origin Protocol",
+  "y1XLjhDfGPVB8olV9Pp0Ow==": "Sorry, there was an error calculating shipping costs."
 }


### PR DESCRIPTION
A user (Shop Admin) on Discord reported that "taxes are showing up as being thousands of dollars", when they "have it set at 6.25%". After confirming the issue on my dev environment (by setting a tax rate of 10% for a randomly chosen country), I'm proposing a solution for it via this PR.

#### Screenshot (before):
![Tax-calc-before](https://user-images.githubusercontent.com/10854442/117138258-67b65880-adc8-11eb-9cfd-7b2d9071084f.png)

#### Screenshot (after):
![Tax-calc-after](https://user-images.githubusercontent.com/10854442/117138288-7270ed80-adc8-11eb-9525-824a8400ed6b.png)


