### PR TITLE
Incorrect hostname used in deployments

### DIFF
--- a/backend/routes/shops.js
+++ b/backend/routes/shops.js
@@ -663,7 +663,6 @@ module.exports = function (router) {
     if (!shop) {
       return res.json({ success: false, reason: 'shop-not-found' })
     }
-    const dataDir = authToken
     const { networkId } = req.body
     let resourceSelection = req.body.resourceSelection
 
@@ -696,7 +695,7 @@ module.exports = function (router) {
       {
         uuid,
         networkId: networkId ? networkId : network.networkId,
-        subdomain: dataDir,
+        subdomain: shop.hostname,
         shopId: shop.id,
         resourceSelection
       },


### PR DESCRIPTION
Looks like a not-insignificant chunk of shops are running into a domain conflict causing deploy failures after the recent addition of a validation check.  This uses `shop.hostname` instead of `dataDir` (auth_token) for deployment subdomain in the deploy route to help normalize things a bit more.  

This might not be the only cause of the conflict.  We were playing kinda fast and loose with DNS names.  Will continue to monitor and work on fixing.