### PR TITLE
Policy pages theme support

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -84,6 +84,7 @@
   },
   "devDependencies": {
     "chai": "4.3.0",
+    "chai-http": "^4.3.0",
     "chai-string": "1.5.0",
     "eslint": "7.19.0",
     "mocha": "8.2.1",

--- a/shop/package.json
+++ b/shop/package.json
@@ -47,6 +47,7 @@
     "@origin/services": "^0.1.0",
     "@origin/utils": "^0.1.0",
     "@popperjs/core": "^2.6.0",
+    "@tailwindcss/typography": "^0.4.1",
     "@uphold/uphold-sdk-javascript": "^2.4.0",
     "@web3-react/core": "^6.1.1",
     "@web3-react/injected-connector": "^6.0.7",

--- a/shop/package.json
+++ b/shop/package.json
@@ -47,7 +47,7 @@
     "@origin/services": "^0.1.0",
     "@origin/utils": "^0.1.0",
     "@popperjs/core": "^2.6.0",
-    "@tailwindcss/typography": "^0.4.1",
+    "@tailwindcss/typography": "0.2.0",
     "@uphold/uphold-sdk-javascript": "^2.4.0",
     "@web3-react/core": "^6.1.1",
     "@web3-react/injected-connector": "^6.0.7",

--- a/shop/src/components/DisplayShopPolicy.js
+++ b/shop/src/components/DisplayShopPolicy.js
@@ -3,7 +3,7 @@ import fbt from 'fbt'
 
 import Link from 'components/Link'
 
-const displayPolicy = ({ heading, text }) => {
+const DisplayPolicy = ({ heading, text }) => {
   return (
     <>
       <div className="collection">
@@ -24,7 +24,7 @@ const displayPolicy = ({ heading, text }) => {
   )
 }
 
-export default displayPolicy
+export default DisplayPolicy
 
 require('react-styl')(`
   .policy-text

--- a/shop/src/components/DisplayShopPolicy.js
+++ b/shop/src/components/DisplayShopPolicy.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import fbt from 'fbt'
+
+import Link from 'components/Link'
+
+const displayPolicy = ({ heading, text }) => {
+  return (
+    <>
+      <div className="collection">
+        <div className="breadcrumbs">
+          <Link to="/" className="linkToHome">
+            <fbt desc="Home">Home</fbt>
+          </Link>
+          <span>{heading}</span>
+        </div>
+        <div className="d-flex flex-row justify-content-between align-items-center">
+          <h3>{heading}</h3>
+        </div>
+      </div>
+      <div className="policy-text">
+        {!text ? null : <div dangerouslySetInnerHTML={{ __html: text }} />}
+      </div>
+    </>
+  )
+}
+
+export default displayPolicy
+
+require('react-styl')(`
+  .policy-text
+    max-width: 700px
+    a
+      text-decoration: underline
+    h1
+      font-size: 24px
+    h2
+      font-size: 18px
+`)

--- a/shop/src/themes/art/app.css
+++ b/shop/src/themes/art/app.css
@@ -49,10 +49,6 @@
   .align-items-center{
     @apply items-center
   }
-
-  .policy-text {
-    max-width: 700px;
-  }
 }
 
 body {

--- a/shop/src/themes/art/app.css
+++ b/shop/src/themes/art/app.css
@@ -27,6 +27,32 @@
   .btn-link, a {
     color: var(--link-color);
   }
+
+  .breadcrumbs {
+    @apply mb-6
+  }
+
+  .linkToHome:after {
+      content:  ">";
+      padding:  0 0.25rem;
+      text-decoration:  none;
+    }
+
+  .d-flex {
+    @apply flex
+  }
+
+  .justify-content-between{
+    @apply justify-between
+  }
+
+  .align-items-center{
+    @apply items-center
+  }
+
+  .policy-text {
+    max-width: 700px;
+  }
 }
 
 body {

--- a/shop/src/themes/art/components/Storefront.js
+++ b/shop/src/themes/art/components/Storefront.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { Switch, Route } from 'react-router-dom'
 
 import Home from './Home'
@@ -11,7 +11,37 @@ import Cart from '../../shared/Cart'
 import Header from './_Header'
 import Footer from './_Footer'
 
+import DisplayPolicy from 'components/DisplayShopPolicy'
+import useConfig from 'utils/useConfig'
+
 const Storefront = () => {
+  const { config } = useConfig()
+  const [policies, setPolicies] = useState([['', '', false]])
+
+  useEffect(() => {
+    fetch(`/shop/policies`, {
+      method: 'GET',
+      headers: {
+        authorization: `bearer ${encodeURIComponent(config.backendAuthToken)}`
+      }
+    })
+      .then((res) => {
+        if (!res.ok) {
+          return null
+        } else {
+          return res.json() //Expected type: <Array<Array<String, String, boolean>>>
+        }
+      })
+      .then((result) => {
+        if (result) {
+          setPolicies(result)
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load shop policies', err)
+      })
+  }, [window.onload])
+
   return (
     <>
       <Header />
@@ -22,10 +52,19 @@ const Storefront = () => {
         <Route path="/contact" component={Contact} />
         <Route path="/cart" component={Cart} />
         <Route path="/about" component={About} />
+        {policies.map((policy, index) => {
+          return (
+            <Route key={`${index}`} path={`/policy${index + 1}`}>
+              <div className="container prose">
+                <DisplayPolicy heading={policy[0]} text={policy[1]} />
+              </div>
+            </Route>
+          )
+        })}
         <Route component={Home} />
       </Switch>
 
-      <Footer />
+      <Footer policyHeadings={policies.map((pol) => pol[0])} />
     </>
   )
 }

--- a/shop/src/themes/art/components/_Footer.js
+++ b/shop/src/themes/art/components/_Footer.js
@@ -6,7 +6,11 @@ import Link from 'components/Link'
 
 import SocialLinks from 'components/SocialLinks'
 
-const Footer = () => {
+/*
+ * @param policyHeadings <Array<string>> Individual elements of this array are displayed on the footer of a store's website, so that the user can click on them
+ * and be routed to the store's policy pages
+ */
+const Footer = ({ policyHeadings }) => {
   const { config } = useConfig()
 
   const date = new Date()
@@ -53,6 +57,17 @@ const Footer = () => {
             <li className="pb-4 sm:mr-10">
               <Link to="/about">About</Link>
             </li>
+            <div className="policies">
+              {policyHeadings
+                ? policyHeadings.map((element, index) => {
+                    return (
+                      <li key={`${index}`} className="pb-4 sm:mr-10">
+                        <Link to={`/policy${index + 1}`}>{element}</Link>
+                      </li>
+                    )
+                  })
+                : null}
+            </div>
             <li className="pb-4">
               <Link to="/contact">Contact</Link>
             </li>

--- a/shop/src/themes/art/tailwind.config.js
+++ b/shop/src/themes/art/tailwind.config.js
@@ -40,5 +40,6 @@ module.exports = {
         header: ['var(--header-font)', ...defaultTheme.fontFamily.serif]
       }
     }
-  }
+  },
+  plugins: [require('@tailwindcss/typography')]
 }

--- a/shop/src/themes/cake/app.css
+++ b/shop/src/themes/cake/app.css
@@ -50,6 +50,19 @@
   .btn-primary:hover {
     @apply bg-white text-red-400;
   }
+
+  .breadcrumbs {
+    @apply mb-6
+  }
+
+  .linkToHome:after {
+    content:  ">";
+    padding:  0 0.25rem;
+    text-decoration:  none;
+  }
+  .policy-text {
+    max-width: 700px;
+  }
 }
 
 body {

--- a/shop/src/themes/cake/components/Storefront.js
+++ b/shop/src/themes/cake/components/Storefront.js
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { Switch, Route } from 'react-router-dom'
+import fetch from 'node-fetch'
 
 import Home from './Home'
 import Product from './Product'
@@ -10,7 +11,37 @@ import Cart from '../../shared/Cart'
 import Header from './_Header'
 import Footer from './_Footer'
 
+import useConfig from 'utils/useConfig'
+import DisplayPolicy from 'components/DisplayShopPolicy'
+
 const Storefront = () => {
+  const { config } = useConfig()
+  const [policies, setPolicies] = useState([['', '', false]])
+
+  //Get the shop's policies from the DB and store it in the component's state. This data is later used in the routing code.
+  useEffect(() => {
+    fetch(`${config.backend}/shop/policies`, {
+      method: 'GET',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `bearer ${encodeURIComponent(config.backendAuthToken)}`
+      }
+    })
+      .then((res) => {
+        if (!res.ok) {
+          return null
+        } else {
+          return res.json()
+        }
+      })
+      .then((result) => {
+        if (result) {
+          setPolicies(result)
+        }
+      })
+      .catch((err) => console.error('Failed to load shop policies', err))
+  }, [window.onload])
+
   return (
     <div className="font-body">
       <Header />
@@ -20,10 +51,19 @@ const Storefront = () => {
         <Route path="/product/:id" component={Product} />
         <Route path="/cart" component={Cart} />
         <Route path="/about" component={About} />
+        {policies.map((policy, index) => {
+          return (
+            <Route key={index} path={`/policy${index + 1}`}>
+              <div className="container prose">
+                <DisplayPolicy heading={policy[0]} text={policy[1]} />
+              </div>
+            </Route>
+          )
+        })}
         <Route component={Home} />
       </Switch>
 
-      <Footer />
+      <Footer policyHeadings={policies.map((p) => p[0])} />
     </div>
   )
 }

--- a/shop/src/themes/cake/components/_Footer.js
+++ b/shop/src/themes/cake/components/_Footer.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import get from 'lodash/get'
+import fbt from 'fbt'
 import useConfig from 'utils/useConfig'
 import useThemeVars from 'utils/useThemeVars'
 import SocialLinks from 'components/SocialLinks'
+import Link from 'components/Link'
 
-const Footer = () => {
+const Footer = ({ policyHeadings }) => {
   const { config } = useConfig()
   const themeVars = useThemeVars()
   const relativeLogoPath = get(themeVars, 'header.logo.0.url')
@@ -31,22 +33,37 @@ const Footer = () => {
         <div>
           <ul className="flex flex-col sm:flex-row text-red-500 justify-center text-link">
             <li className="pb-4 sm:mr-10">
-              <a href="#">FAQ</a>
+              <Link to="/about">
+                <fbt desc="FAQ">FAQ</fbt>
+              </Link>
             </li>
+            <div className="policies">
+              {/* Display links to a store's policy pages, if and only if the 'policyHeadings' prop is passed a value other than the expected default */}
+              {policyHeadings &&
+                policyHeadings != [''] &&
+                policyHeadings.map((heading, index) => {
+                  return (
+                    <li key={index} className="pb-4 sm:mr-10">
+                      <Link to={`/policy${index + 1}`}>
+                        <fbt desc="policy">
+                          <fbt:param name="heading">{heading}</fbt:param>
+                        </fbt>
+                      </Link>
+                    </li>
+                  )
+                })}
+            </div>
             <li className="pb-4 sm:mr-10">
               <a href="#">About Dshop</a>
             </li>
             <li className="pb-4 sm:mr-10">
               <a href="#">Visit Origin</a>
             </li>
-            <li className="pb-4">
-              <a href="#">Support</a>
-            </li>
           </ul>
         </div>
         <div className="flex flex-col sm:flex-row pb-8 sm:pb-0 justify-center text-secondary">
           <div className="mr-10">Powered by Origin Dshop</div>
-          <div>© 2020 Origin Protocol</div>
+          <div>© 2021 Origin Protocol</div>
         </div>
       </div>
     </div>

--- a/shop/src/themes/cake/tailwind.config.js
+++ b/shop/src/themes/cake/tailwind.config.js
@@ -36,5 +36,6 @@ module.exports = {
         header: ['var(--header-font)', ...defaultTheme.fontFamily.serif]
       }
     }
-  }
+  },
+  plugins: [require('@tailwindcss/typography')]
 }

--- a/shop/src/themes/poly/app.css
+++ b/shop/src/themes/poly/app.css
@@ -47,6 +47,28 @@
   .btn-primary:hover {
     @apply bg-black text-orange-400;
   }
+  
+  .breadcrumbs {
+    @apply mb-6
+  }
+
+  .linkToHome:after {
+      content:  ">";
+      padding:  0 0.25rem;
+      text-decoration:  none;
+    }
+
+  .d-flex {
+    @apply flex
+  }
+
+  .justify-content-between{
+    @apply justify-between
+  }
+
+  .align-items-center{
+    @apply items-center
+  }
 }
 
 @media (min-width: 768px) {

--- a/shop/src/themes/poly/components/Storefront.js
+++ b/shop/src/themes/poly/components/Storefront.js
@@ -1,16 +1,35 @@
-import React from 'react'
+import fetch from 'node-fetch'
+import React, { useState, useEffect } from 'react'
 import { Switch, Route } from 'react-router-dom'
 
+import useConfig from 'utils/useConfig'
 import Home from './Home'
 import Product from './Product'
 import Products from './Products'
 import About from './About'
 import Cart from '../../shared/Cart'
+import DisplayPolicy from 'components/DisplayShopPolicy'
 
 import Header from './_Header'
 import Footer from './_Footer'
 
 const Storefront = () => {
+  const { config } = useConfig()
+  const [policies, setPolicies] = useState(['', '', false])
+
+  useEffect(() => {
+    fetch('/shop/policies', {
+      method: 'GET',
+      headers: {
+        authorization: `bearer ${encodeURIComponent(config.backendAuthToken)}`,
+        'content-type': 'application/json'
+      }
+    })
+      .then((res) => (!res.ok ? null : res.json())) //Expected type: <Array<Array<String, String, boolean>>>
+      .then((result) => (result ? setPolicies(result) : null))
+      .catch((err) => console.error('Failed to load shop policies', err))
+  }, [window.onload])
+
   return (
     <>
       <Header />
@@ -20,10 +39,19 @@ const Storefront = () => {
         <Route path="/product/:id" component={Product} />
         <Route path="/cart" component={Cart} />
         <Route path="/about" component={About} />
+        {policies.map((policy, index) => {
+          return (
+            <Route key={index} path={`/policy${index + 1}`}>
+              <div className="container prose">
+                <DisplayPolicy heading={policy[0]} text={policy[1]} />
+              </div>
+            </Route>
+          )
+        })}
         <Route component={Home} />
       </Switch>
 
-      <Footer />
+      <Footer policyHeadings={policies.map((p) => p[0])} />
     </>
   )
 }

--- a/shop/src/themes/poly/components/_Footer.js
+++ b/shop/src/themes/poly/components/_Footer.js
@@ -5,7 +5,12 @@ import useConfig from 'utils/useConfig'
 import Link from 'components/Link'
 import SocialLinks from 'components/SocialLinks'
 import useThemeVars from 'utils/useThemeVars'
-const Footer = () => {
+
+/*
+ * @param policyHeadings <Array<string>> Individual elements of this array are displayed on the footer of a store's website, so that the user can click on them
+ * and be routed to the store's policy pages
+ */
+const Footer = ({ policyHeadings }) => {
   const { config } = useConfig()
   const date = new Date()
   const themeVars = useThemeVars()
@@ -50,6 +55,18 @@ const Footer = () => {
           <Link to="/about" className="hover:opacity-75">
             About
           </Link>
+          <ul>
+            {/* Display links to policy pages if and only if the prop 'policyHeadings' is passed a value other than the expected default */}
+            {policyHeadings &&
+              policyHeadings != [''] &&
+              policyHeadings.map((heading, index) => {
+                return (
+                  <li key={`${index}`}>
+                    <Link to={`/policy${index + 1}`}>{heading}</Link>
+                  </li>
+                )
+              })}
+          </ul>
         </div>
       </div>
     </div>

--- a/shop/src/themes/poly/tailwind.config.js
+++ b/shop/src/themes/poly/tailwind.config.js
@@ -31,6 +31,31 @@ module.exports = {
       fontFamily: {
         sans: ['"Garamond Pro"', ...defaultTheme.fontFamily.sans]
       }
-    }
-  }
+    },
+    typography: (theme) => ({
+      default: {
+        css: {
+          color: '#ffffff',
+          a: { color: theme('colors.orange.400') },
+          h1: { color: '#ffffff' },
+          h2: { color: '#ffffff' },
+          h3: { color: '#ffffff' },
+          h4: { color: '#ffffff' },
+          h5: { color: '#ffffff' },
+          h6: { color: '#ffffff' },
+          strong: { color: '#ffffff' },
+          blockquote: { color: '#ffffff' },
+          code: { color: '#ffffff' },
+          th: { color: '#ffffff' },
+          td: {
+            borderTop: '#ffffff',
+            borderBottom: '#ffffff',
+            borderRight: '#ffffff',
+            borderLeft: '#ffffff'
+          }
+        }
+      }
+    }) //Note: The code under the 'typography' key is in accordance with the docs for @tailwindcss/typography v.0.2.0
+  },
+  plugins: [require('@tailwindcss/typography')]
 }

--- a/shop/src/themes/ybm/app.css
+++ b/shop/src/themes/ybm/app.css
@@ -44,6 +44,27 @@
   .btn-secondary:hover {
     @apply bg-black text-white;
   }
+  .breadcrumbs {
+    @apply mt-4 mb-6
+  }
+    .linkToHome:after {
+      content:  ">";
+      padding:  0 0.25rem;
+      text-decoration:  none;
+    }
+
+  .d-flex {
+    @apply flex
+  }
+
+  .justify-content-between{
+    @apply justify-between
+  }
+
+  .align-items-center{
+    @apply items-center
+  }
+
 }
 
 body {

--- a/shop/src/themes/ybm/components/About.js
+++ b/shop/src/themes/ybm/components/About.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import get from 'lodash/get'
 
 import useConfig from 'utils/useConfig'
@@ -6,6 +6,7 @@ import useThemeVars from 'utils/useThemeVars'
 
 import Header from './_Header'
 import Footer from './_Footer'
+import { getPolicies } from './Policies'
 
 const About = () => {
   const { config } = useConfig()
@@ -17,6 +18,18 @@ const About = () => {
   const primaryImage = get(themeVars, 'about.primaryImage.0', {})
   const aboutImages = get(themeVars, 'about.aboutImages', [])
 
+  const [policyHeadings, setHeadings] = useState([''])
+  useEffect(() => {
+    const updatePolicies = async () => {
+      getPolicies(config.backendAuthToken).then(({ policyHeads, policies }) => {
+        setHeadings(policyHeads)
+      })
+    }
+
+    updatePolicies()
+  }, [])
+
+  console.log(`policyHeads: `, policyHeadings)
   return (
     <>
       <Header
@@ -89,7 +102,7 @@ const About = () => {
           </div>
         </div>
       </div>
-      <Footer />
+      <Footer policyHeadings={policyHeadings} />
     </>
   )
 }

--- a/shop/src/themes/ybm/components/About.js
+++ b/shop/src/themes/ybm/components/About.js
@@ -21,15 +21,14 @@ const About = () => {
   const [policyHeadings, setHeadings] = useState([''])
   useEffect(() => {
     const updatePolicies = async () => {
-      getPolicies(config.backendAuthToken).then(({ policyHeads, policies }) => {
-        setHeadings(policyHeads)
+      getPolicies(config.backendAuthToken).then((obj) => {
+        setHeadings(obj.policyHeads)
       })
     }
 
     updatePolicies()
   }, [])
 
-  console.log(`policyHeads: `, policyHeadings)
   return (
     <>
       <Header

--- a/shop/src/themes/ybm/components/Cart.js
+++ b/shop/src/themes/ybm/components/Cart.js
@@ -1,15 +1,28 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 
+import useConfig from 'utils/useConfig'
 import Header from './_Header'
 import Footer from './_Footer'
 import Cart from '../../shared/Cart'
+import { getPolicies } from './Policies'
 
 const CartWrapper = () => {
+  const { config } = useConfig()
+  const [policyHeadings, setHeadings] = useState([''])
+  useEffect(() => {
+    const updatePolicies = async () => {
+      getPolicies(config.backendAuthToken).then(({ policyHeads, policies }) => {
+        setHeadings(policyHeads)
+      })
+    }
+
+    updatePolicies()
+  }, [])
   return (
     <>
       <Header />
       <Cart />
-      <Footer />
+      <Footer policyHeadings={policyHeadings} />
     </>
   )
 }

--- a/shop/src/themes/ybm/components/Cart.js
+++ b/shop/src/themes/ybm/components/Cart.js
@@ -11,8 +11,8 @@ const CartWrapper = () => {
   const [policyHeadings, setHeadings] = useState([''])
   useEffect(() => {
     const updatePolicies = async () => {
-      getPolicies(config.backendAuthToken).then(({ policyHeads, policies }) => {
-        setHeadings(policyHeads)
+      getPolicies(config.backendAuthToken).then((obj) => {
+        setHeadings(obj.policyHeads)
       })
     }
 

--- a/shop/src/themes/ybm/components/Contact.js
+++ b/shop/src/themes/ybm/components/Contact.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import get from 'lodash/get'
 
 import useConfig from 'utils/useConfig'
@@ -8,6 +8,7 @@ import SocialLink from 'components/SocialLink'
 
 import Header from './_Header'
 import Footer from './_Footer'
+import { getPolicies } from './Policies'
 
 const Contact = () => {
   const { config } = useConfig()
@@ -17,7 +18,16 @@ const Contact = () => {
   const header = get(themeVars, 'contact.headerImage.0', {})
   const contactEmail = get(themeVars, 'contact.email', config.supportEmail)
   const contactNumber = get(themeVars, 'contact.number', config.supportPhone)
+  const [policyHeadings, setHeadings] = useState([''])
+  useEffect(() => {
+    const updatePolicies = async () => {
+      getPolicies(config.backendAuthToken).then(({ policyHeads, policies }) => {
+        setHeadings(policyHeads)
+      })
+    }
 
+    updatePolicies()
+  }, [])
   return (
     <>
       <Header
@@ -72,7 +82,7 @@ const Contact = () => {
           )}
         </div>
       </div>
-      <Footer />
+      <Footer policyHeadings={policyHeadings} />
     </>
   )
 }

--- a/shop/src/themes/ybm/components/Contact.js
+++ b/shop/src/themes/ybm/components/Contact.js
@@ -21,8 +21,8 @@ const Contact = () => {
   const [policyHeadings, setHeadings] = useState([''])
   useEffect(() => {
     const updatePolicies = async () => {
-      getPolicies(config.backendAuthToken).then(({ policyHeads, policies }) => {
-        setHeadings(policyHeads)
+      getPolicies(config.backendAuthToken).then((obj) => {
+        setHeadings(obj.policyHeads)
       })
     }
 

--- a/shop/src/themes/ybm/components/Home.js
+++ b/shop/src/themes/ybm/components/Home.js
@@ -44,19 +44,6 @@ const Home = () => {
 
   return (
     <>
-      <HashRouter>
-        <Switch>
-          {policies.map((policy, index) => {
-            return (
-              <Route key={`${index}`} path={`/policy${index + 1}`}>
-                <div className="container prose">
-                  <DisplayPolicy heading={policy[0]} text={policy[1]} />
-                </div>
-              </Route>
-            )
-          })}
-        </Switch>
-      </HashRouter>
       <Header>
         <div
           className="text-center px-4 mt-24 text-3xl sm:text-5xl leading-tight mx-auto"

--- a/shop/src/themes/ybm/components/Home.js
+++ b/shop/src/themes/ybm/components/Home.js
@@ -1,45 +1,27 @@
 import React, { useState, useEffect } from 'react'
-import { HashRouter, Switch, Route } from 'react-router-dom'
 import get from 'lodash/get'
 
 import useConfig from 'utils/useConfig'
-
 import Link from 'components/Link'
-import DisplayPolicy from 'components/DisplayShopPolicy'
-
 import useThemeVars from 'utils/useThemeVars'
 
 import Header from './_Header'
 import Footer from './_Footer'
 import Collections from './_Collections'
+import { getPolicies } from './Policies'
 
 const Home = () => {
   const { config } = useConfig()
   const themeVars = useThemeVars()
-  const [policies, setPolicies] = useState([['', '', false]])
-
+  const [policyHeadings, setHeadings] = useState([''])
   useEffect(() => {
-    fetch(`/shop/policies`, {
-      method: 'GET',
-      headers: {
-        authorization: `bearer ${encodeURIComponent(config.backendAuthToken)}`
-      }
-    })
-      .then((res) => {
-        if (!res.ok) {
-          return null
-        } else {
-          return res.json() //Expected type: <Array<Array<String, String, boolean>>>
-        }
+    const updatePolicies = async () => {
+      getPolicies(config.backendAuthToken).then((obj) => {
+        setHeadings(obj.policyHeads)
       })
-      .then((result) => {
-        if (result) {
-          setPolicies(result)
-        }
-      })
-      .catch((err) => {
-        console.error('Failed to load shop policies', err)
-      })
+    }
+
+    updatePolicies()
   }, [window.onload])
 
   return (
@@ -70,7 +52,7 @@ const Home = () => {
           View All Products
         </Link>
       </div>
-      <Footer policyHeadings={policies.map((pol) => pol[0])} />
+      <Footer policyHeadings={policyHeadings} />
     </>
   )
 }

--- a/shop/src/themes/ybm/components/Home.js
+++ b/shop/src/themes/ybm/components/Home.js
@@ -1,9 +1,11 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import { HashRouter, Switch, Route } from 'react-router-dom'
 import get from 'lodash/get'
 
 import useConfig from 'utils/useConfig'
 
 import Link from 'components/Link'
+import DisplayPolicy from 'components/DisplayShopPolicy'
 
 import useThemeVars from 'utils/useThemeVars'
 
@@ -14,9 +16,47 @@ import Collections from './_Collections'
 const Home = () => {
   const { config } = useConfig()
   const themeVars = useThemeVars()
+  const [policies, setPolicies] = useState([['', '', false]])
+
+  useEffect(() => {
+    fetch(`/shop/policies`, {
+      method: 'GET',
+      headers: {
+        authorization: `bearer ${encodeURIComponent(config.backendAuthToken)}`
+      }
+    })
+      .then((res) => {
+        if (!res.ok) {
+          return null
+        } else {
+          return res.json() //Expected type: <Array<Array<String, String, boolean>>>
+        }
+      })
+      .then((result) => {
+        if (result) {
+          setPolicies(result)
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load shop policies', err)
+      })
+  }, [window.onload])
 
   return (
     <>
+      <HashRouter>
+        <Switch>
+          {policies.map((policy, index) => {
+            return (
+              <Route key={`${index}`} path={`/policy${index + 1}`}>
+                <div className="container prose">
+                  <DisplayPolicy heading={policy[0]} text={policy[1]} />
+                </div>
+              </Route>
+            )
+          })}
+        </Switch>
+      </HashRouter>
       <Header>
         <div
           className="text-center px-4 mt-24 text-3xl sm:text-5xl leading-tight mx-auto"
@@ -43,7 +83,7 @@ const Home = () => {
           View All Products
         </Link>
       </div>
-      <Footer />
+      <Footer policyHeadings={policies.map((pol) => pol[0])} />
     </>
   )
 }

--- a/shop/src/themes/ybm/components/Policies.js
+++ b/shop/src/themes/ybm/components/Policies.js
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from 'react'
+import { HashRouter, Switch, Route } from 'react-router-dom'
+import DisplayPolicy from 'components/DisplayShopPolicy'
+import useConfig from 'utils/useConfig'
+
+import Header from './_Header'
+import Footer from './_Footer'
+
+/*
+ * @function getPolicies
+ * @param authToken<string> The shop's backend authToken
+ * @returns Promise<<object> : { policyHeads: <Array<string>>, policies: <Array<Array<String, String, boolean>>>}>
+ */
+const getPolicies = (authToken) => {
+  let policyHeads = ['']
+  let policies = [['', '', false]]
+
+  return fetch(`/shop/policies`, {
+    method: 'GET',
+    headers: {
+      authorization: `bearer ${encodeURIComponent(authToken)}`
+    }
+  })
+    .then((res) => {
+      if (!res.ok) {
+        return null
+      } else {
+        return res.json() //Expected type: <Array<Array<String, String, boolean>>>
+      }
+    })
+    .then((result) => {
+      if (result) {
+        policyHeads = result.map((policy) => policy[0])
+        policies = result
+      }
+      return { policyHeads: policyHeads, policies: policies }
+    })
+    .catch((err) => {
+      console.error('Failed to load shop policies', err)
+    })
+}
+
+/*
+ * @component PolicyPage
+ * Renders a shop's policy pages
+ */
+
+const PolicyPage = () => {
+  const { config } = useConfig()
+  const [policyHeadings, setHeadings] = useState([''])
+  const [policies, setPolicies] = useState([['', '', false]])
+
+  console.log('Loaded PolicyPage component')
+  useEffect(() => {
+    const updatePolicies = async () => {
+      getPolicies(config.backendAuthToken).then(({ policyHeads, policies }) => {
+        setHeadings(policyHeads)
+        setPolicies(policies)
+      })
+    }
+
+    updatePolicies()
+  }, [])
+
+  return (
+    <>
+      <Header />
+      <HashRouter>
+        <Switch>
+          {policies.map((policy, index) => {
+            return (
+              <Route key={`${index}`} path={`/policy${index + 1}`}>
+                <div className="container prose">
+                  <DisplayPolicy heading={policy[0]} text={policy[1]} />
+                </div>
+              </Route>
+            )
+          })}
+        </Switch>
+      </HashRouter>
+      <Footer policyHeadings={policyHeadings} />
+    </>
+  )
+}
+
+export { getPolicies, PolicyPage }

--- a/shop/src/themes/ybm/components/Policies.js
+++ b/shop/src/themes/ybm/components/Policies.js
@@ -50,7 +50,6 @@ const PolicyPage = () => {
   const [policyHeadings, setHeadings] = useState([''])
   const [policies, setPolicies] = useState([['', '', false]])
 
-  console.log('Loaded PolicyPage component')
   useEffect(() => {
     const updatePolicies = async () => {
       getPolicies(config.backendAuthToken).then(({ policyHeads, policies }) => {

--- a/shop/src/themes/ybm/components/Products.js
+++ b/shop/src/themes/ybm/components/Products.js
@@ -26,8 +26,8 @@ const AllProducts = () => {
   const [policyHeadings, setHeadings] = useState([''])
   useEffect(() => {
     const updatePolicies = async () => {
-      getPolicies(config.backendAuthToken).then(({ policyHeads, policies }) => {
-        setHeadings(policyHeads)
+      getPolicies(config.backendAuthToken).then((obj) => {
+        setHeadings(obj.policyHeads)
       })
     }
 
@@ -60,7 +60,7 @@ const AllProducts = () => {
       <div className="sm:container mb-12">
         <Products collection={collection} sort={opts.sort} />
       </div>
-      <Footer policyHeadings={policyHeads} />
+      <Footer policyHeadings={policyHeadings} />
     </>
   )
 }

--- a/shop/src/themes/ybm/components/Products.js
+++ b/shop/src/themes/ybm/components/Products.js
@@ -1,16 +1,18 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { useRouteMatch, useHistory } from 'react-router-dom'
 import get from 'lodash/get'
 
 import useCollections from 'utils/useCollections'
 import useSearchQuery from 'utils/useSearchQuery'
 import useThemeVars from 'utils/useThemeVars'
+import useConfig from 'utils/useConfig'
 
 import SortBy from 'components/SortBy'
 
 import Header from './_Header'
 import Footer from './_Footer'
 import Products from './_Products'
+import { getPolicies } from './Policies'
 
 const AllProducts = () => {
   const history = useHistory()
@@ -19,6 +21,18 @@ const AllProducts = () => {
   const match = useRouteMatch('/collections/:collection')
   const opts = useSearchQuery()
   const collection = get(match, 'params.collection')
+
+  const { config } = useConfig()
+  const [policyHeadings, setHeadings] = useState([''])
+  useEffect(() => {
+    const updatePolicies = async () => {
+      getPolicies(config.backendAuthToken).then(({ policyHeads, policies }) => {
+        setHeadings(policyHeads)
+      })
+    }
+
+    updatePolicies()
+  }, [])
 
   return (
     <>
@@ -46,7 +60,7 @@ const AllProducts = () => {
       <div className="sm:container mb-12">
         <Products collection={collection} sort={opts.sort} />
       </div>
-      <Footer />
+      <Footer policyHeadings={policyHeads} />
     </>
   )
 }

--- a/shop/src/themes/ybm/components/_Footer.js
+++ b/shop/src/themes/ybm/components/_Footer.js
@@ -72,17 +72,22 @@ const Footer = ({ policyHeadings }) => {
             About
           </Link>
           <div className="policies">
-          <ul className="flex flex-col sm:flex-row ">
-            {policyHeadings
-              ? policyHeadings.map((element, index) => {
-                  return (
-                    <li key={`${index}`}>
-                      <Link className="hover:opacity-75" to={`/policy${index + 1}`}>{element}</Link>
-                    </li>
-                  )
-                })
-              : null}
-          </ul>
+            <ul className="grid gap-2 sm:gap-6 grid-flow-row sm:grid-flow-col text-center sm:text-left">
+              {policyHeadings
+                ? policyHeadings.map((element, index) => {
+                    return (
+                      <li key={`${index}`}>
+                        <Link
+                          className="hover:opacity-75"
+                          to={`/policy${index + 1}`}
+                        >
+                          {element}
+                        </Link>
+                      </li>
+                    )
+                  })
+                : null}
+            </ul>
           </div>
           <Link className="hover:opacity-75" to="/contact">
             Contact

--- a/shop/src/themes/ybm/components/_Footer.js
+++ b/shop/src/themes/ybm/components/_Footer.js
@@ -10,7 +10,11 @@ import CurrencySelect from 'components/CurrencySelect'
 import SocialLink from 'components/SocialLink'
 import Link from 'components/Link'
 
-const Footer = () => {
+/*
+ * @param policyHeadings <Array<string>> Individual elements of this array are displayed on the footer of a store's website, so that the user can click on them
+ * and be routed to the store's policy pages
+ */
+const Footer = ({ policyHeadings }) => {
   const { config } = useConfig()
   const themeVars = useThemeVars()
 
@@ -67,6 +71,19 @@ const Footer = () => {
           <Link className="hover:opacity-75" to="/about">
             About
           </Link>
+          <div className="policies">
+          <ul className="flex flex-col sm:flex-row ">
+            {policyHeadings
+              ? policyHeadings.map((element, index) => {
+                  return (
+                    <li key={`${index}`}>
+                      <Link className="hover:opacity-75" to={`/policy${index + 1}`}>{element}</Link>
+                    </li>
+                  )
+                })
+              : null}
+          </ul>
+          </div>
           <Link className="hover:opacity-75" to="/contact">
             Contact
           </Link>

--- a/shop/src/themes/ybm/index.js
+++ b/shop/src/themes/ybm/index.js
@@ -7,7 +7,6 @@ import './app.css'
 import DshopProvider from 'components/DshopProvider'
 import PreviewBanner from 'components/PreviewBanner'
 import ProductRedirect from 'components/ProductRedirect'
-import DisplayPolicy from 'components/DisplayShopPolicy'
 
 import Cart from './components/Cart'
 import Home from './components/Home'
@@ -15,12 +14,11 @@ import About from './components/About'
 import Contact from './components/Contact'
 import Products from './components/Products'
 import Product from './components/Product'
+import { PolicyPage } from './components/Policies'
 import Confirmation from '../shared/Confirmation'
 import Checkout from '../shared/checkout/Loader'
 
 const Providers = () => {
-
-  
   return (
     <HashRouter>
       <DshopProvider>
@@ -42,6 +40,17 @@ const Providers = () => {
           ></Route>
           <Route path="/collections/:collection" component={Products} />
           <Route path="/cart" component={Cart} />
+          <Route
+            path={[
+              '/policy1',
+              '/policy2',
+              '/policy3',
+              '/policy4',
+              '/policy5',
+              '/policy6'
+            ]}
+            component={PolicyPage}
+          />
           <Route path="/" component={Home} />
         </Switch>
       </DshopProvider>

--- a/shop/src/themes/ybm/index.js
+++ b/shop/src/themes/ybm/index.js
@@ -7,6 +7,7 @@ import './app.css'
 import DshopProvider from 'components/DshopProvider'
 import PreviewBanner from 'components/PreviewBanner'
 import ProductRedirect from 'components/ProductRedirect'
+import DisplayPolicy from 'components/DisplayShopPolicy'
 
 import Cart from './components/Cart'
 import Home from './components/Home'
@@ -18,6 +19,8 @@ import Confirmation from '../shared/Confirmation'
 import Checkout from '../shared/checkout/Loader'
 
 const Providers = () => {
+
+  
   return (
     <HashRouter>
       <DshopProvider>

--- a/shop/src/themes/ybm/tailwind.config.js
+++ b/shop/src/themes/ybm/tailwind.config.js
@@ -34,5 +34,6 @@ module.exports = {
         }
       }
     }
-  }
+  },
+  plugins: [require('@tailwindcss/typography')]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3681,6 +3681,11 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
   integrity sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==
 
+"@types/chai@4":
+  version "4.2.22"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.22.tgz#47020d7e4cf19194d43b5202f35f75bd2ad35ce7"
+  integrity sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==
+
 "@types/component-emitter@^1.2.10":
   version "1.2.10"
   resolved "https://registry.yarnpkg.com/@types/component-emitter/-/component-emitter-1.2.10.tgz#ef5b1589b9f16544642e473db5ea5639107ef3ea"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3593,6 +3593,16 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tailwindcss/typography@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.4.1.tgz#51ddbceea6a0ee9902c649dbe58871c81a831212"
+  integrity sha512-ovPPLUhs7zAIJfr0y1dbGlyCuPhpuv/jpBoFgqAc658DWGGrOBWBMpAWLw2KlzbNeVk4YBJMzue1ekvIbdw6XA==
+  dependencies:
+    lodash.castarray "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+    lodash.uniq "^4.5.0"
+
 "@tokenizer/token@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz#f0d92c12f87079ddfd1b29f614758b9696bc29e3"
@@ -16084,6 +16094,11 @@ lodash.bind@^4.1.4:
   resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
   integrity sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=
 
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+  integrity sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU=
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -16139,6 +16154,11 @@ lodash.ismatch@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
 lodash.map@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
@@ -16154,7 +16174,7 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.merge@4.6.2, lodash.merge@^4.4.0, lodash.merge@^4.6.0:
+lodash.merge@4.6.2, lodash.merge@^4.4.0, lodash.merge@^4.6.0, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3593,15 +3593,10 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@tailwindcss/typography@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.4.1.tgz#51ddbceea6a0ee9902c649dbe58871c81a831212"
-  integrity sha512-ovPPLUhs7zAIJfr0y1dbGlyCuPhpuv/jpBoFgqAc658DWGGrOBWBMpAWLw2KlzbNeVk4YBJMzue1ekvIbdw6XA==
-  dependencies:
-    lodash.castarray "^4.4.0"
-    lodash.isplainobject "^4.0.6"
-    lodash.merge "^4.6.2"
-    lodash.uniq "^4.5.0"
+"@tailwindcss/typography@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.2.0.tgz#b597c83502e3c3c6641a8aaabda223cd494ab349"
+  integrity sha512-aPgMH+CjQiScLZculoDNOQUrrK2ktkbl3D6uCLYp1jgYRlNDrMONu9nMu8LfwAeetYNpVNeIGx7WzHSu0kvECg==
 
 "@tokenizer/token@^0.1.1":
   version "0.1.1"
@@ -16094,11 +16089,6 @@ lodash.bind@^4.1.4:
   resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
   integrity sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=
 
-lodash.castarray@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
-  integrity sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU=
-
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -16154,11 +16144,6 @@ lodash.ismatch@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
 
-lodash.isplainobject@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
-  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
-
 lodash.map@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
@@ -16174,7 +16159,7 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.merge@4.6.2, lodash.merge@^4.4.0, lodash.merge@^4.6.0, lodash.merge@^4.6.2:
+lodash.merge@4.6.2, lodash.merge@^4.4.0, lodash.merge@^4.6.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==


### PR DESCRIPTION
Follow up on #988

The PR referenced above allows shop admins to set custom 'policy pages' for their stores. However, it lacked support for the different themes available on the platform. 
As a test of these changes, I'm including a screen-capture that previews a shop in my dev environment, with some generic text in place of the 'policies':

https://user-images.githubusercontent.com/10854442/140047726-93d0e9f0-24b7-4dbf-a6ab-ba18b984635f.mov


Jump to:
0:34 Testing the Default theme
1:18 Testing Art/"Minimal"
2:29 Testing Cake/"Artisan"
3:33 Testing Poly/"Showcase"
4:26 Testing YBM/"Galleria"