### PR TITLE
Display taxes in order summary on shops using themes

### DIFF
--- a/shop/src/themes/shared/checkout/Information.js
+++ b/shop/src/themes/shared/checkout/Information.js
@@ -12,6 +12,8 @@ import Link from 'components/Link'
 import CountrySelect from 'components/CountrySelect'
 import ProvinceSelect from 'components/ProvinceSelect'
 
+import determineTaxes from './_Taxes'
+
 export const Information = () => {
   const history = useHistory()
   const [{ cart }, dispatch] = useStateValue()
@@ -32,38 +34,10 @@ export const Information = () => {
           return
         }
         dispatch({ type: 'updateUserInfo', info: newState })
-
-        //Calculate taxes
-        try {
-          if (config.taxRates.length) {
-            const taxedCountry = config.taxRates.find(
-              (obj) => obj.country == Countries[newState.country].code
-            )
-
-            //If taxes are configured on the 'country' level, do this
-            let taxRate = get(taxedCountry, 'rate', 0)
-
-            //If taxes are configured at the 'province' level, do this
-            if (newState.province && taxedCountry.provinces) {
-              const currentProvinceCode = get(
-                Countries[newState.country].provinces,
-                newState.province
-              )['code']
-
-              for (const provinceObject of taxedCountry.provinces) {
-                if (provinceObject.province == currentProvinceCode) {
-                  taxRate = provinceObject.rate
-                  break
-                }
-              }
-            }
-
-            dispatch({ type: 'updateTaxRate', taxRate })
-          }
-        } catch (err) {
-          console.error('Error: Taxes not added to cart', err)
-        }
-
+        dispatch({
+          type: 'updateTaxRate',
+          taxRate: determineTaxes(config, newState)
+        })
         history.push({
           pathname: '/checkout/shipping',
           state: { scrollToTop: true }
@@ -175,6 +149,7 @@ export const MobileInformation = () => {
       return
     }
     dispatch({ type: 'updateUserInfo', info: newState })
+
     history.push('/checkout/shipping-address')
   }
   return (

--- a/shop/src/themes/shared/checkout/Shipping.js
+++ b/shop/src/themes/shared/checkout/Shipping.js
@@ -17,6 +17,7 @@ import Link from 'components/Link'
 import CountrySelect from 'components/CountrySelect'
 import ProvinceSelect from 'components/ProvinceSelect'
 
+import determineTaxes from './_Taxes'
 import { ContactInfo, ShippingAddress } from './_Summary'
 
 const Picker = ({ className }) => {
@@ -156,38 +157,10 @@ export const MobileShippingAddress = () => {
       return
     }
     dispatch({ type: 'updateUserInfo', info: newState })
-
-    //Calculate taxes
-    try {
-      if (config.taxRates.length) {
-        const taxedCountry = config.taxRates.find(
-          (obj) => obj.country == Countries[newState.country].code
-        )
-
-        //If taxes are configured on the 'country' level, do this
-        let taxRate = get(taxedCountry, 'rate', 0)
-
-        //If taxes are configured at the 'province' level, do this
-        if (newState.province && taxedCountry.provinces) {
-          const currentProvinceCode = get(
-            Countries[newState.country].provinces,
-            newState.province
-          )['code']
-
-          for (const provinceObject of taxedCountry.provinces) {
-            if (provinceObject.province == currentProvinceCode) {
-              taxRate = provinceObject.rate
-              break
-            }
-          }
-        }
-
-        dispatch({ type: 'updateTaxRate', taxRate })
-      }
-    } catch (err) {
-      console.error('Error: Taxes not added to cart', err)
-    }
-
+    dispatch({
+      type: 'updateTaxRate',
+      taxRate: determineTaxes(config, newState)
+    })
     history.push('/checkout/shipping')
   }
   return (

--- a/shop/src/themes/shared/checkout/Shipping.js
+++ b/shop/src/themes/shared/checkout/Shipping.js
@@ -9,6 +9,7 @@ import { Countries, CountriesDefaultInfo } from '@origin/utils/Countries'
 import { useStateValue } from 'data/state'
 import useShipping from 'utils/useShipping'
 import useCurrencyOpts from 'utils/useCurrencyOpts'
+import useConfig from 'utils/useConfig'
 import validate from 'data/validations/checkoutInfo'
 import useForm from 'utils/useForm'
 
@@ -141,6 +142,7 @@ export const MobileShippingAddress = () => {
     errorClassName: 'bg-red-100 border-red-700',
     feedbackClassName: 'text-red-700 mt-1 text-sm'
   })
+  const { config } = useConfig()
 
   const country = Countries[state.country] || 'United States'
 
@@ -154,6 +156,38 @@ export const MobileShippingAddress = () => {
       return
     }
     dispatch({ type: 'updateUserInfo', info: newState })
+
+    //Calculate taxes
+    try {
+      if (config.taxRates.length) {
+        const taxedCountry = config.taxRates.find(
+          (obj) => obj.country == Countries[newState.country].code
+        )
+
+        //If taxes are configured on the 'country' level, do this
+        let taxRate = get(taxedCountry, 'rate', 0)
+
+        //If taxes are configured at the 'province' level, do this
+        if (newState.province && taxedCountry.provinces) {
+          const currentProvinceCode = get(
+            Countries[newState.country].provinces,
+            newState.province
+          )['code']
+
+          for (const provinceObject of taxedCountry.provinces) {
+            if (provinceObject.province == currentProvinceCode) {
+              taxRate = provinceObject.rate
+              break
+            }
+          }
+        }
+
+        dispatch({ type: 'updateTaxRate', taxRate })
+      }
+    } catch (err) {
+      console.error('Error: Taxes not added to cart', err)
+    }
+
     history.push('/checkout/shipping')
   }
   return (

--- a/shop/src/themes/shared/checkout/_Summary.js
+++ b/shop/src/themes/shared/checkout/_Summary.js
@@ -128,7 +128,7 @@ function name(cart) {
 }
 
 function address(cart) {
-  return 'address1 address2 city zip country'
+  return 'address1 address2 city province zip country'
     .split(' ')
     .map((i) => get(cart, `userInfo.${i}`))
     .filter((i) => i)

--- a/shop/src/themes/shared/checkout/_Taxes.js
+++ b/shop/src/themes/shared/checkout/_Taxes.js
@@ -1,0 +1,43 @@
+import get from 'lodash/get'
+import { Countries } from '@origin/utils/Countries'
+
+/*
+ * @function determineTaxRateOnOrder Determines if the customer will need to pay taxes on their order, based on their shipping location
+ * @param shopConfig <object> The shop's configuration
+ * @param state <object> the State object of the component calling the function
+ * @returns taxRate <integer> fixed point number with a scaling factor of 1/100, representing the configured tax rate (Ex: 1800 => 18%)
+ */
+
+const determineTaxRateOnOrder = (shopConfig, state) => {
+  try {
+    let taxRate = 0
+    if (shopConfig.taxRates.length) {
+      const taxedCountry = shopConfig.taxRates.find(
+        (obj) => obj.country == Countries[state.country].code
+      )
+
+      //If taxes are configured on the 'country' level, do this
+      taxRate = get(taxedCountry, 'rate', 0)
+
+      //If taxes are configured at the 'province' level, do this
+      if (state.province && taxedCountry.provinces) {
+        const currentProvinceCode = get(
+          Countries[state.country].provinces,
+          state.province
+        )['code']
+
+        for (const provinceObject of taxedCountry.provinces) {
+          if (provinceObject.province == currentProvinceCode) {
+            taxRate = provinceObject.rate
+            break
+          }
+        }
+      }
+    }
+    return taxRate
+  } catch (err) {
+    console.error('Error: Taxes not added to cart', err)
+  }
+}
+
+export default determineTaxRateOnOrder


### PR DESCRIPTION
### Issue: 
On the `master` branch, only users of the **Default** theme can charge taxes on orders. 
I am committing code that's intended to support this feature for other themes. 

_UI testing_ performed in my dev environment:

https://user-images.githubusercontent.com/10854442/142399872-3d0c2f80-95f9-43bb-8c77-e2c0a6401440.mov

Jump to:
0:53 - Test that taxes are loaded for a customer from a taxed 'province' [Desktop]
2:09 - Test that taxes are loaded for a customer from a taxed 'country' [Desktop]
3:20 - Test that taxes are loaded for a customer from a taxed 'country' [Mobile]
4:06 - Test that taxes are loaded for a customer from a taxed 'province' [Mobile]

**Important**
In the video, the **value** of tax calculated is incorrect; this has been addressed with help from @franckc (see https://github.com/OriginProtocol/dshop/pull/939/commits/727cc097e614ca65d05cd1b748e162a78d14d6bd).