### PR TITLE
AWS container compliance - SES integration

### DIFF
--- a/backend/scripts/aws/marketplace/startup_script.sh
+++ b/backend/scripts/aws/marketplace/startup_script.sh
@@ -64,8 +64,8 @@ sudo -u dshop yarn build:dist
 cd $BACKEND_PATH
 truncate -s 0 .env
 
-# Env var indicating it is a AWS deployment.
-echo "AWS_MARKETPLACE_DEPLOYMENT=true" >> .env
+# Env var indicating it is a AWS deployment. Append this to the env files in both the 'backend' and 'shop' folders
+echo "AWS_MARKETPLACE_DEPLOYMENT=true" | tee -a .env ../shop/.env
 
 # Encryption key for storing data securely in the DB.
 echo "ENCRYPTION_KEY=`openssl rand -base64 48`" >> .env

--- a/backend/utils/const.js
+++ b/backend/utils/const.js
@@ -68,7 +68,8 @@ const {
   IPFS_GATEWAY, // IPFS gateway override
   BUCKET_PREFIX = DEFAULT_BUCKET_PREFIX,
   SERVICE_PREFIX = DEFAULT_SERVICE_PREFIX,
-  EXTERNAL_IP
+  EXTERNAL_IP,
+  AWS_MARKETPLACE_DEPLOYMENT //bool indicating whether the app is running from an AWS EC2 instance launched via the marketplace
 } = process.env
 
 /**
@@ -128,6 +129,7 @@ module.exports = {
   BUCKET_PREFIX,
   SERVICE_PREFIX,
   EXTERNAL_IP,
+  AWS_MARKETPLACE_DEPLOYMENT,
   EXTERNAL_IP_SERVICE_URL,
   DEFAULT_INFRA_RESOURCES,
   DEFAULT_AWS_REGION,

--- a/backend/utils/emails/_getTransport.js
+++ b/backend/utils/emails/_getTransport.js
@@ -1,6 +1,6 @@
 const nodemailer = require('nodemailer')
 const aws = require('aws-sdk')
-// const { IS_TEST } = require('../const')
+const { AWS_MARKETPLACE_DEPLOYMENT } = require('../const')
 const encConf = require('../encryptedConfig')
 
 function getTransportFromConfig(config) {
@@ -24,12 +24,23 @@ function getTransportFromConfig(config) {
       }
     })
   } else if (config.email === 'aws') {
-    const SES = new aws.SES({
-      apiVersion: '2010-12-01',
-      region: config.awsRegion,
-      accessKeyId: config.awsAccessKey,
-      secretAccessKey: config.awsAccessSecret
-    })
+    let SES
+
+    if (AWS_MARKETPLACE_DEPLOYMENT) {
+      //Use the credentials from the EC2 Instance metadata
+      SES = new aws.SES({
+        apiVersion: '2010-12-01'
+      })
+    } else {
+      //Look up the shop admin's AWS credentials from 'config'
+      SES = new aws.SES({
+        apiVersion: '2010-12-01',
+        region: config.awsRegion,
+        accessKeyId: config.awsAccessKey,
+        secretAccessKey: config.awsAccessSecret
+      })
+    }
+
     return nodemailer.createTransport({ SES })
   }
 }

--- a/backend/utils/emails/_getTransport.js
+++ b/backend/utils/emails/_getTransport.js
@@ -1,6 +1,6 @@
 const nodemailer = require('nodemailer')
 const aws = require('aws-sdk')
-const { AWS_MARKETPLACE_DEPLOYMENT } = require('../const')
+const { AWS_MARKETPLACE_DEPLOYMENT, DEFAULT_AWS_REGION } = require('../const')
 const encConf = require('../encryptedConfig')
 
 function getTransportFromConfig(config) {
@@ -29,7 +29,8 @@ function getTransportFromConfig(config) {
     if (AWS_MARKETPLACE_DEPLOYMENT) {
       //Use the credentials from the EC2 Instance metadata
       SES = new aws.SES({
-        apiVersion: '2010-12-01'
+        apiVersion: '2010-12-01',
+        region: DEFAULT_AWS_REGION
       })
     } else {
       //Look up the shop admin's AWS credentials from 'config'

--- a/backend/utils/emails/newOrder.js
+++ b/backend/utils/emails/newOrder.js
@@ -159,8 +159,8 @@ async function sendNewOrderEmail({
     ...varsOverride
   }
 
-  const htmlOutputVendor = mjml2html(vendor(vars), { minify: true })
-  const htmlOutput = mjml2html(email(vars), { minify: true })
+  const htmlOutputVendor = mjml2html(vendor(vars))
+  const htmlOutput = mjml2html(email(vars))
   const txtOutput = emailTxt(vars)
 
   const message = {

--- a/backend/utils/emails/passwordReset.js
+++ b/backend/utils/emails/passwordReset.js
@@ -30,7 +30,7 @@ async function sendPasswordResetEmail({ network, seller, verifyUrl, skip }) {
     fromEmail: from
   }
 
-  const htmlOutput = mjml2html(forgotPassEmail(vars), { minify: true })
+  const htmlOutput = mjml2html(forgotPassEmail(vars))
   const txtOutput = forgotPassEmailTxt(vars)
 
   const message = {

--- a/backend/utils/emails/printfulOrderFailed.js
+++ b/backend/utils/emails/printfulOrderFailed.js
@@ -39,7 +39,7 @@ async function sendPrintfulOrderFailedEmail(shopId, orderData, opts, skip) {
     fromEmail: from
   }
 
-  const htmlOutput = mjml2html(printfulOrderFailed(vars), { minify: true })
+  const htmlOutput = mjml2html(printfulOrderFailed(vars))
   const txtOutput = printfulOrderFailedTxt(vars)
 
   const message = {

--- a/backend/utils/emails/sellerContact.js
+++ b/backend/utils/emails/sellerContact.js
@@ -35,7 +35,7 @@ async function sellerContactEmail({ network, seller, data, skip }) {
     fromEmail: from
   }
 
-  const htmlOutput = mjml2html(sellerContact(vars), { minify: true })
+  const htmlOutput = mjml2html(sellerContact(vars))
   const txtOutput = sellerContactTxt(vars)
 
   const message = {

--- a/backend/utils/emails/stripeWebhookError.js
+++ b/backend/utils/emails/stripeWebhookError.js
@@ -32,7 +32,7 @@ async function stripeWebhookErrorEmail(shopId, errorData, skip) {
     ...errorData
   }
 
-  const htmlOutput = mjml2html(stripeWebhookError(vars), { minify: true })
+  const htmlOutput = mjml2html(stripeWebhookError(vars))
   const txtOutput = stripeWebhookErrorTxt(vars)
 
   const message = {

--- a/backend/utils/emails/verifyEmail.js
+++ b/backend/utils/emails/verifyEmail.js
@@ -24,7 +24,7 @@ async function sendVerifyEmail({ network, seller, verifyUrl, skip }) {
   const { name, email } = seller
   const vars = { head, name, verifyUrl, fromEmail: from }
 
-  const htmlOutput = mjml2html(verifyEmail(vars), { minify: true })
+  const htmlOutput = mjml2html(verifyEmail(vars))
   const txtOutput = verifyEmailTxt(vars)
 
   const message = {

--- a/shop/src/pages/admin/settings/Server.js
+++ b/shop/src/pages/admin/settings/Server.js
@@ -277,7 +277,8 @@ const AdminSettings = ({ shop }) => {
               </div>
             </>
           )}
-          {state.email !== 'aws' ? null : (
+          {state.email !== 'aws' &&
+          !process.env.AWS_MARKETPLACE_DEPLOYMENT ? null : (
             <>
               <div className="form-group">
                 <label>AWS Region</label>

--- a/shop/src/pages/admin/settings/apps/List.js
+++ b/shop/src/pages/admin/settings/apps/List.js
@@ -19,7 +19,6 @@ import ProcessorsList from 'components/settings/ProcessorsList'
 
 const AppSettings = () => {
   const { shopConfig, refetch } = useShopConfig()
-  const [{ config }, dispatch] = useStateValue()
   const [connectModal, setShowConnectModal] = useState(false)
   const { emailAppsList } = useEmailAppsList({ shopConfig })
   const { post } = useBackendApi({ authToken: true })
@@ -90,10 +89,6 @@ const AppSettings = () => {
                     } catch (err) {
                       console.error(err)
                     }
-                    // dispatch({
-                    //   type: 'setConfig',
-                    //   config: { ...shopConfig, ...config, email: 'aws' }
-                    // })
                     refetch()
                   } else {
                     setShowConnectModal(processor.id)

--- a/shop/src/pages/admin/settings/apps/List.js
+++ b/shop/src/pages/admin/settings/apps/List.js
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react'
 import fbt, { FbtParam } from 'fbt'
 
 import useShopConfig from 'utils/useShopConfig'
+import useStateValue from 'data/state'
 import useEmailAppsList from 'utils/useEmailAppsList'
 import maskSecret from 'utils/maskSecret'
 
@@ -17,6 +18,7 @@ import ProcessorsList from 'components/settings/ProcessorsList'
 
 const AppSettings = () => {
   const { shopConfig, refetch } = useShopConfig()
+  const [, dispatch] = useStateValue()
   const [connectModal, setShowConnectModal] = useState(false)
   const { emailAppsList } = useEmailAppsList({ shopConfig })
 
@@ -89,7 +91,13 @@ const AppSettings = () => {
       ModalToRender = SendgridModal
       break
     case 'aws':
-      ModalToRender = AWSModal
+    process.env.AWS_MARKETPLACE_DEPLOYMENT = true; 
+      process.env.AWS_MARKETPLACE_DEPLOYMENT
+        ? dispatch({
+            type: 'setConfigSimple',
+            config: { ...shopConfig, email: 'aws' }
+          })
+        : (ModalToRender = AWSModal)
       break
     case 'mailgun':
       ModalToRender = MailgunModal

--- a/shop/src/pages/admin/settings/apps/List.js
+++ b/shop/src/pages/admin/settings/apps/List.js
@@ -2,7 +2,6 @@ import React, { useMemo, useState } from 'react'
 import fbt, { FbtParam } from 'fbt'
 
 import useShopConfig from 'utils/useShopConfig'
-import { useStateValue } from 'data/state'
 import useBackendApi from 'utils/useBackendApi'
 import useEmailAppsList from 'utils/useEmailAppsList'
 import maskSecret from 'utils/maskSecret'
@@ -22,9 +21,6 @@ const AppSettings = () => {
   const [connectModal, setShowConnectModal] = useState(false)
   const { emailAppsList } = useEmailAppsList({ shopConfig })
   const { post } = useBackendApi({ authToken: true })
-
-  //Comment out the line below after testing is complete
-  process.env.AWS_MARKETPLACE_DEPLOYMENT = true
 
   const appsList = useMemo(() => {
     if (!shopConfig) return []

--- a/shop/src/pages/super-admin/networks/_Form.js
+++ b/shop/src/pages/super-admin/networks/_Form.js
@@ -198,6 +198,32 @@ const NetworkForm = ({ onSave, network, feedback, className }) => {
     shopConfig: state.fallbackShopConfig
   })
 
+  /*
+   * The Networks form should ask the shop admin for their AWS Credentials only when the DShop DApp is not deployed on an EC2 instance launched via AWS Marketplace.
+   * Reason: When DShop is deployed with the help of the Marketplace solution, the shop admin's AWS credentials can be obtained programatically.
+   * Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials
+   */
+  const conditionallyRequestAWSCreds = () => {
+    if (process.env.AWS_MARKETPLACE_DEPLOYMENT) {
+      return
+    } else {
+      return (
+        <div className="form-row">
+          <div className="form-group col-md-6">
+            <label>AWS Access Key ID</label>
+            <input {...input('awsAccessKeyId')} />
+            {Feedback('awsAccessKeyId')}
+          </div>
+          <div className="form-group col-md-6">
+            <label>AWS Secret Access Key</label>
+            <PasswordField field="awsSecretAccessKey" input={input} />
+            {Feedback('awsSecretAccessKey')}
+          </div>
+        </div>
+      )
+    }
+  }
+
   const ProcessorIdToEmailComp = {
     sendgrid: SendgridModal,
     aws: AWSModal,
@@ -408,18 +434,7 @@ const NetworkForm = ({ onSave, network, feedback, className }) => {
           {Feedback('gcpCredentials')}
         </div>
       </div>
-      <div className="form-row">
-        <div className="form-group col-md-6">
-          <label>AWS Access Key ID</label>
-          <input {...input('awsAccessKeyId')} />
-          {Feedback('awsAccessKeyId')}
-        </div>
-        <div className="form-group col-md-6">
-          <label>AWS Secret Access Key</label>
-          <PasswordField field="awsSecretAccessKey" input={input} />
-          {Feedback('awsSecretAccessKey')}
-        </div>
-      </div>
+      {conditionallyRequestAWSCreds()}
       <div className="form-row">
         <div className="form-group col-md-6">
           <label>Discord Webhook</label>

--- a/shop/src/pages/super-admin/networks/_Form.js
+++ b/shop/src/pages/super-admin/networks/_Form.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useMemo } from 'react'
 import { validateSelection } from '@origin/dshop-validation/matrix'
 
 import useSetState from 'utils/useSetState'
-import useShopConfig from 'utils/useShopConfig'
 import { Networks } from 'data/Networks'
 import { formInput, formFeedback } from 'utils/formHelpers'
 import PasswordField from 'components/admin/PasswordField'
@@ -146,9 +145,6 @@ function validate(state) {
 }
 
 const NetworkForm = ({ onSave, network, feedback, className }) => {
-  //Comment out the line below after testing is complete
-  process.env.AWS_MARKETPLACE_DEPLOYMENT = true
-
   const [advanced, setAdvanced] = useState(false)
   // NOTE: defaultShopConfig is stored as string, probably
   // to make it editable from a text field.

--- a/shop/src/pages/super-admin/networks/_Form.js
+++ b/shop/src/pages/super-admin/networks/_Form.js
@@ -146,8 +146,6 @@ function validate(state) {
 }
 
 const NetworkForm = ({ onSave, network, feedback, className }) => {
-  const { post } = useBackendApi({ authToken: true })
-  const { refetch } = useShopConfig()
   //Comment out the line below after testing is complete
   process.env.AWS_MARKETPLACE_DEPLOYMENT = true
 
@@ -266,18 +264,14 @@ const NetworkForm = ({ onSave, network, feedback, className }) => {
                   process.env.AWS_MARKETPLACE_DEPLOYMENT &&
                   processor.id == 'aws'
                 ) {
-                  try {
-                    await post('/shop/config', {
-                      method: 'PUT',
-                      body: JSON.stringify({ email: 'aws' }),
-                      suppressError: true
-                    })
-                  } catch (err) {
-                    console.error(err)
-                  }
-                  refetch()
+                  setState({
+                    fallbackShopConfig: {
+                      ...state.fallbackShopConfig,
+                      email: 'aws'
+                    }
+                  })
                 } else {
-                  setShowConnectModal(processor.id)
+                  setConfigureEmailModal(processor.id)
                 }
               }}
             >

--- a/shop/src/utils/useEmailAppsList.js
+++ b/shop/src/utils/useEmailAppsList.js
@@ -33,9 +33,10 @@ const useEmailAppsList = ({ shopConfig }) => {
       {
         id: 'aws',
         title: 'AWS SES',
-        description: awsEnabled
-          ? `AWS SES Access Key: ${maskSecret(awsAccessKey, 12)}`
-          : 'Send emails using AWS SES',
+        description:
+          awsEnabled && !process.env.AWS_MARKETPLACE_DEPLOYMENT
+            ? `AWS SES Access Key: ${maskSecret(awsAccessKey, 12)}`
+            : 'Send emails using AWS SES',
         icon: <img src="images/aws-ses.png" width="60%" />,
         enabled: awsEnabled
       },

--- a/shop/webpack.config.js
+++ b/shop/webpack.config.js
@@ -224,7 +224,9 @@ const webpackConfig = {
       DATA_DIR: process.env.DATA_DIR || '',
       CONTENT_CDN: process.env.CONTENT_CDN || '',
       CONTENT_HASH: process.env.CONTENT_HASH || '',
-      ABSOLUTE: process.env.ABSOLUTE || ''
+      ABSOLUTE: process.env.ABSOLUTE || '',
+      AWS_MARKETPLACE_DEPLOYMENT:
+        false || process.env.AWS_MARKETPLACE_DEPLOYMENT
     }),
     new MiniCssExtractPlugin({ filename: '[name].[contenthash:8].css' })
   ],


### PR DESCRIPTION
Addresses #1011.

See related PR: [#1029](https://github.com/OriginProtocol/dshop/pull/1029)

If a shop admin deploys DShop from an Amazon EC2 instance, the app will now refrain from requesting the admin's AWS credentials in the Super Admin network config page. If and when the admin attempts to connect the app to their AWS SES account, the app will try to establish a connection using the EC2 "[instance metadata service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials)".